### PR TITLE
TryGo to spawn goroutine, put frames back on fail

### DIFF
--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -344,7 +344,7 @@ func (l *BatchSubmitter) loop() {
 		l.publishStateToL1(queue, receiptsCh, daGroup)
 		if !l.Txmgr.IsClosed() {
 			l.Log.Info("Wait for pure DA writes, not L1 txs")
-			daGroup.Wait()
+			_ = daGroup.Wait()
 			l.Log.Info("Wait for L1 writes (blobs or DA commitments)")
 			queue.Wait()
 		} else {


### PR DESCRIPTION
This keeps the concurrency handling more localized and avoids the strange dummy goroutine.