### PR TITLE
ci: add fork-sync to sync our dev branch with optimism's dev branch

### DIFF
--- a/.github/.workflows/fork-sync.yaml
+++ b/.github/.workflows/fork-sync.yaml
@@ -1,0 +1,19 @@
+# This workflow will open a PR every 30 minutes to sync our develop branch with optimism's develop branch.
+# Our actual fork with eigenda related patches is in eigenda-develop branch, which needs to be manually synced with the develop branch.
+name: Sync Fork
+
+on:
+  schedule:
+    - cron: "*/30 * * * *" # every 30 minutes
+  workflow_dispatch: # on button click
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: tgymnich/fork-sync@v1.8
+        with:
+          owner: ethereum-optimism
+          base: develop
+          head: develop


### PR DESCRIPTION
First time trying this. Not sure what's the best way to manage this fork.
Currently thinking we have:
1. layr-labs:develop which is automatically synced by this action to optimism:develop
2. we will maintain our altda patch in the `eigenda-develop` branch, and manually rebase it on top of layr-labs:develop branch (which is auto-synced to optimism:develop) whenever needed.

We might want eventually to also use fork-sync to automatically create PRs to rebase our eigenda-develop patch directly to optimism:develop... not sure.