### PR TITLE
fix(damgr): failover altda->ethda should keep finalizing l2 chain

### DIFF
--- a/.github/workflows/test-golang.yml
+++ b/.github/workflows/test-golang.yml
@@ -50,6 +50,7 @@ jobs:
         packages:
           - op-batcher
           - op-node
+          - op-alt-da
           - op-e2e/system/altda
           - op-e2e/actions/altda
     steps:

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -117,7 +117,7 @@ func TestFailoverToEthDACalldata(t *testing.T) {
 // Test Harness, which contains all the state needed to run the tests.
 // harness also defines some higher-level "require" methods that are used in the tests.
 type harness struct {
-	log                 log.Logger
+	logger              log.Logger
 	endpoints           *EnclaveServicePublicEndpoints
 	clients             *EnclaveServiceClients
 	batchInboxAddr      common.Address
@@ -125,7 +125,7 @@ type harness struct {
 }
 
 func newHarness(t *testing.T) *harness {
-	log := testlog.Logger(t, slog.LevelInfo)
+	logger := testlog.Logger(t, slog.LevelInfo)
 
 	// We leave 20 seconds to build the entire testHarness.
 	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 20*time.Second)
@@ -143,7 +143,7 @@ func newHarness(t *testing.T) *harness {
 	require.NoError(t, err)
 	t.Logf("Endpoints: %+v", endpoints)
 
-	clients, err := getClientsFromEndpoints(ctxWithTimeout, log, endpoints)
+	clients, err := getClientsFromEndpoints(ctxWithTimeout, logger, endpoints)
 	require.NoError(t, err)
 
 	// Get the batch inbox address from the rollup config
@@ -155,7 +155,7 @@ func newHarness(t *testing.T) *harness {
 	require.NoError(t, err)
 
 	return &harness{
-		log:                 log,
+		logger:              logger,
 		endpoints:           endpoints,
 		clients:             clients,
 		batchInboxAddr:      rollupConfig.BatchInboxAddress,
@@ -394,13 +394,13 @@ type EnclaveServiceClients struct {
 	proxyMemconfigClient *ProxyMemconfigClient
 }
 
-func getClientsFromEndpoints(ctx context.Context, log log.Logger, endpoints *EnclaveServicePublicEndpoints) (*EnclaveServiceClients, error) {
-	opNodeClient, err := dial.DialRollupClientWithTimeout(ctx, 10*time.Second, log, endpoints.OpNodeEndpoint)
+func getClientsFromEndpoints(ctx context.Context, logger log.Logger, endpoints *EnclaveServicePublicEndpoints) (*EnclaveServiceClients, error) {
+	opNodeClient, err := dial.DialRollupClientWithTimeout(ctx, 10*time.Second, logger, endpoints.OpNodeEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("dial.DialRollupClientWithTimeout: %w", err)
 	}
 
-	opGethClient, err := dial.DialEthClientWithTimeout(ctx, 10*time.Second, log, endpoints.OpGethEndpoint)
+	opGethClient, err := dial.DialEthClientWithTimeout(ctx, 10*time.Second, logger, endpoints.OpGethEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("dial.DialEthClientWithTimeout: %w", err)
 	}

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -388,9 +388,14 @@ func getPublicEndpointsFromKurtosis(enclaveCtx *enclaves.EnclaveContext) (*Encla
 }
 
 type EnclaveServiceClients struct {
-	opNodeClient         *sources.RollupClient
-	opGethClient         *ethclient.Client
-	gethL1Client         *ethclient.Client
+	// opNode and opGeth are the L2 clients for the rollup.
+	opNodeClient *sources.RollupClient
+	// opGeth is the client for the L2 execution layer client.
+	opGethClient *ethclient.Client
+	// gethL1 is the client for the L1 chain execution layer client.
+	gethL1Client *ethclient.Client
+	// proxyMemconfigClient is the client for the eigenda-proxy's memstore config API.
+	// It allows us to toggle the proxy's failover behavior.
 	proxyMemconfigClient *ProxyMemconfigClient
 }
 

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"reflect"
@@ -14,9 +15,12 @@ import (
 
 	"github.com/Layr-Labs/eigenda-proxy/clients/memconfig_client"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
+	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/enclaves"
 	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
 	"github.com/stretchr/testify/require"
@@ -35,12 +39,10 @@ const enclaveName = "eigenda-memstore-devnet"
 //
 // Note: because this test relies on modifying the proxy's memstore config, it should be run in isolation.
 // That is, if we ever implement more kurtosis tests, they would currently need to be run sequentially.
-//
-// TODO: We will also need to test the failover behavior of the node, which currently doesn't finalize after failover (fixed in https://github.com/Layr-Labs/optimism/pull/23)
 func TestFailoverToEthDACalldata(t *testing.T) {
 	deadline, ok := t.Deadline()
 	if !ok {
-		deadline = time.Now().Add(1 * time.Minute)
+		deadline = time.Now().Add(10 * time.Minute)
 	}
 	ctxWithDeadline, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
@@ -48,7 +50,7 @@ func TestFailoverToEthDACalldata(t *testing.T) {
 	harness := newHarness(t)
 	t.Cleanup(func() {
 		// switch proxy back to normal mode, in case test gets cancelled
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		err := harness.clients.proxyMemconfigClient.Failback(ctx)
 		if err != nil {
@@ -75,7 +77,7 @@ func TestFailoverToEthDACalldata(t *testing.T) {
 	harness.requireBatcherTxsToBeFromLayer(t, fromBlock, fromBlock+l1BlocksQueriedForBatcherTxs, DALayerEigenDA)
 
 	// 2. Failover and check that the commitments are now EthDACalldata
-	t.Logf("Failover over... changing proxy's config to return 503 errors")
+	t.Logf("Failing over... changing proxy's config to return 503 errors")
 	err := harness.clients.proxyMemconfigClient.Failover(ctxWithDeadline)
 	require.NoError(t, err)
 
@@ -86,6 +88,16 @@ func TestFailoverToEthDACalldata(t *testing.T) {
 	require.NoError(t, err)
 
 	harness.requireBatcherTxsToBeFromLayer(t, afterFailoverFromBlockNum, afterFailoverToBlockNum, DALayerEthCalldata)
+
+	// We also check that the op-node is still finalizing blocks after the failover
+	syncStatus, err := harness.clients.opNodeClient.SyncStatus(ctxWithDeadline)
+	require.NoError(t, err)
+	afterFailoverFinalizedL2 := syncStatus.FinalizedL2
+	t.Logf("Current finalized L2 block: %d. Waiting for next block to finalize to make sure finalization is still happening.", afterFailoverFinalizedL2.Number)
+	// On average would expect this to take half an epoch, aka 16 L1 blocks, which at 6 sec/block means 1.5 minutes.
+	// This generally takes longer (3-6 minutes), but I'm not quite sure why.
+	_, err = geth.WaitForBlockToBeFinalized(new(big.Int).SetUint64(afterFailoverFinalizedL2.Number+1), harness.clients.opGethClient, 6*time.Minute)
+	require.NoError(t, err, "op-node should still be finalizing blocks after failover")
 
 	// 3. Failback and check that the commitments are EigenDA again
 	t.Logf("Failing back... changing proxy's config to start processing PUT requests normally again")
@@ -105,6 +117,7 @@ func TestFailoverToEthDACalldata(t *testing.T) {
 // Test Harness, which contains all the state needed to run the tests.
 // harness also defines some higher-level "require" methods that are used in the tests.
 type harness struct {
+	log                 log.Logger
 	endpoints           *EnclaveServicePublicEndpoints
 	clients             *EnclaveServiceClients
 	batchInboxAddr      common.Address
@@ -112,6 +125,8 @@ type harness struct {
 }
 
 func newHarness(t *testing.T) *harness {
+	log := testlog.Logger(t, slog.LevelInfo)
+
 	// We leave 20 seconds to build the entire testHarness.
 	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
@@ -128,14 +143,11 @@ func newHarness(t *testing.T) *harness {
 	require.NoError(t, err)
 	t.Logf("Endpoints: %+v", endpoints)
 
-	clients, err := getClientsFromEndpoints(endpoints)
+	clients, err := getClientsFromEndpoints(ctxWithTimeout, log, endpoints)
 	require.NoError(t, err)
 
-	// Get the batch inbox address
-	var rollupConfigMap struct {
-		BatchInboxAddress string `json:"batch_inbox_address"`
-	}
-	err = clients.opNodeClient.CallContext(ctxWithTimeout, &rollupConfigMap, "optimism_rollupConfig")
+	// Get the batch inbox address from the rollup config
+	rollupConfig, err := clients.opNodeClient.RollupConfig(ctxWithTimeout)
 	require.NoError(t, err)
 
 	// Get the current L1 block number
@@ -143,9 +155,10 @@ func newHarness(t *testing.T) *harness {
 	require.NoError(t, err)
 
 	return &harness{
+		log:                 log,
 		endpoints:           endpoints,
 		clients:             clients,
-		batchInboxAddr:      common.HexToAddress(rollupConfigMap.BatchInboxAddress),
+		batchInboxAddr:      rollupConfig.BatchInboxAddress,
 		testStartL1BlockNum: testStartL1BlockNum,
 	}
 }
@@ -315,6 +328,7 @@ func fetchBatcherTxs(gethL1Endpoint string, batchInbox string, fromBlockNum, toB
 // The public endpoints are the ones that are exposed to the host machine.
 type EnclaveServicePublicEndpoints struct {
 	OpNodeEndpoint       string `kurtosis:"op-cl-1-op-node-op-geth-op-kurtosis,http"`
+	OpGethEndpoint       string `kurtosis:"op-el-1-op-geth-op-node-op-kurtosis,rpc"`
 	GethL1Endpoint       string `kurtosis:"el-1-geth-teku,rpc"`
 	EigendaProxyEndpoint string `kurtosis:"da-server-op-kurtosis,http"`
 	// Adding new endpoints is as simple as adding a new field with a kurtosis tag
@@ -374,17 +388,24 @@ func getPublicEndpointsFromKurtosis(enclaveCtx *enclaves.EnclaveContext) (*Encla
 }
 
 type EnclaveServiceClients struct {
-	opNodeClient         *rpc.Client
+	opNodeClient         *sources.RollupClient
+	opGethClient         *ethclient.Client
 	gethL1Client         *ethclient.Client
 	proxyMemconfigClient *ProxyMemconfigClient
 }
 
-func getClientsFromEndpoints(endpoints *EnclaveServicePublicEndpoints) (*EnclaveServiceClients, error) {
-	opNodeClient, err := rpc.Dial(endpoints.OpNodeEndpoint)
+func getClientsFromEndpoints(ctx context.Context, log log.Logger, endpoints *EnclaveServicePublicEndpoints) (*EnclaveServiceClients, error) {
+	opNodeClient, err := dial.DialRollupClientWithTimeout(ctx, 10*time.Second, log, endpoints.OpNodeEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("rpc.Dial: %w", err)
+		return nil, fmt.Errorf("dial.DialRollupClientWithTimeout: %w", err)
 	}
 
+	opGethClient, err := dial.DialEthClientWithTimeout(ctx, 10*time.Second, log, endpoints.OpGethEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("dial.DialEthClientWithTimeout: %w", err)
+	}
+
+	// TODO: prob also change to use dial.DialEthClient?
 	gethL1Client, err := ethclient.Dial(endpoints.GethL1Endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("ethclient.Dial: %w", err)
@@ -396,6 +417,7 @@ func getClientsFromEndpoints(endpoints *EnclaveServicePublicEndpoints) (*Enclave
 
 	return &EnclaveServiceClients{
 		opNodeClient:         opNodeClient,
+		opGethClient:         opGethClient,
 		gethL1Client:         gethL1Client,
 		proxyMemconfigClient: proxyMemconfigClient,
 	}, nil

--- a/op-alt-da/damgr.go
+++ b/op-alt-da/damgr.go
@@ -421,6 +421,7 @@ func (d *DA) fetchChallengeLogs(ctx context.Context, l1 L1Fetcher, block eth.Blo
 		}
 		for _, log := range rec.Logs {
 			if log.Address == d.cfg.DAChallengeContractAddress && len(log.Topics) > 0 && log.Topics[0] == ChallengeStatusEventABIHash {
+				d.log.Info("found challenge event", "block", block.Number, "log", log.Index)
 				logs = append(logs, log)
 			}
 		}

--- a/op-alt-da/damgr.go
+++ b/op-alt-da/damgr.go
@@ -118,7 +118,10 @@ func (d *DA) updateFinalizedHead(l1Finalized eth.L1BlockRef) {
 	d.l1FinalizedHead = l1Finalized
 	// Prune the state to the finalized head
 	lastPrunedCommIncBlock := d.state.Prune(l1Finalized.ID())
-	d.log.Debug("updateFinalizedHead", "currFinalizedHead", d.finalizedHead.Number, "lastPrunedCommIncBlock", lastPrunedCommIncBlock.Number, "l1Finalized", l1Finalized.Number)
+	d.log.Debug("updateFinalizedHead",
+		"currFinalizedHead", d.finalizedHead.Number,
+		"lastPrunedCommIncBlock", lastPrunedCommIncBlock.Number,
+		"l1Finalized", l1Finalized.Number)
 	// If a commitment was pruned, set the finalized head to that commitment's inclusion block
 	// When no commitments are left to be pruned (one example is if we have failed over to ethda)
 	// then updateFinalizedFromL1 becomes the main driver of the finalized head.

--- a/op-alt-da/damgr_test.go
+++ b/op-alt-da/damgr_test.go
@@ -53,12 +53,12 @@ func TestFinalization(t *testing.T) {
 	require.NoError(t, state.ExpireCommitments(bID(8)))
 	require.Empty(t, state.commitments)
 
-	state.Prune(bID(bn1))
-	require.Equal(t, eth.L1BlockRef{}, state.lastPrunedCommitment)
-	state.Prune(bID(7))
-	require.Equal(t, eth.L1BlockRef{}, state.lastPrunedCommitment)
-	state.Prune(bID(8))
-	require.Equal(t, l1Ref(bn1), state.lastPrunedCommitment)
+	lastPrunedCommitment := state.Prune(bID(bn1))
+	require.Equal(t, eth.L1BlockRef{}, lastPrunedCommitment)
+	lastPrunedCommitment = state.Prune(bID(7))
+	require.Equal(t, eth.L1BlockRef{}, lastPrunedCommitment)
+	lastPrunedCommitment = state.Prune(bID(8))
+	require.Equal(t, l1Ref(bn1), lastPrunedCommitment)
 
 	// Track a commitment, challenge it, & then resolve it
 	c2 := RandomCommitment(rng)
@@ -83,12 +83,12 @@ func TestFinalization(t *testing.T) {
 	require.Empty(t, state.challenges)
 
 	// Now finalize everything
-	state.Prune(bID(20))
-	require.Equal(t, l1Ref(bn1), state.lastPrunedCommitment)
-	state.Prune(bID(28))
-	require.Equal(t, l1Ref(bn1), state.lastPrunedCommitment)
-	state.Prune(bID(32))
-	require.Equal(t, l1Ref(bn2), state.lastPrunedCommitment)
+	lastPrunedCommitment = state.Prune(bID(20))
+	require.Equal(t, eth.L1BlockRef{}, lastPrunedCommitment)
+	lastPrunedCommitment = state.Prune(bID(28))
+	require.Equal(t, eth.L1BlockRef{}, lastPrunedCommitment)
+	lastPrunedCommitment = state.Prune(bID(32))
+	require.Equal(t, l1Ref(bn2), lastPrunedCommitment)
 }
 
 // TestExpireChallenges expires challenges and prunes the state for longer windows
@@ -175,8 +175,8 @@ func TestDAChallengeDetached(t *testing.T) {
 	require.ErrorIs(t, err, ErrReorgRequired)
 
 	// pruning finalized block is safe. It should not prune any commitments yet.
-	state.Prune(bID(1))
-	require.Equal(t, eth.L1BlockRef{}, state.lastPrunedCommitment)
+	lastPrunedCommitment := state.Prune(bID(1))
+	require.Equal(t, eth.L1BlockRef{}, lastPrunedCommitment)
 
 	// Perform reorg back to bn2
 	state.ClearCommitments()

--- a/op-alt-da/damock.go
+++ b/op-alt-da/damock.go
@@ -48,6 +48,8 @@ func (c *MockDAClient) DeleteData(key []byte) error {
 	return c.store.Delete(key)
 }
 
+// DAErrFaker is a DA client that can be configured to return errors on GetInput
+// and SetInput calls.
 type DAErrFaker struct {
 	Client *MockDAClient
 
@@ -109,6 +111,10 @@ func (d *AltDADisabled) AdvanceL1Origin(ctx context.Context, l1 L1Fetcher, block
 //   - request latencies, to mimic a DA service with slow responses
 //     (eg. eigenDA with 10 min batching interval).
 //   - response status codes, to mimic a DA service that is down.
+//
+// We use this FakeDaServer as opposed to the DAErrFaker client in the op-e2e altda system tests
+// because the batcher service only has a constructor to build from CLI flags (no dependency injection),
+// meaning the da client is built from an rpc url config instead of being injected.
 type FakeDAServer struct {
 	*DAServer
 	putRequestLatency time.Duration

--- a/op-alt-da/dastate.go
+++ b/op-alt-da/dastate.go
@@ -206,6 +206,7 @@ func (s *State) ExpireChallenges(origin eth.BlockID) {
 }
 
 // Prune removes challenges & commitments which have an expiry block number beyond the given block number.
+// It returns the last pruned commitment's inclusion block number, or eth.L1BlockRef{} if no commitments were pruned.
 func (s *State) Prune(origin eth.BlockID) eth.L1BlockRef {
 	// Commitments rely on challenges, so we prune commitments first.
 	lastPrunedCommIncBlock := s.pruneCommitments(origin)

--- a/op-e2e/actions/altda/altda_test.go
+++ b/op-e2e/actions/altda/altda_test.go
@@ -644,7 +644,7 @@ func TestAltDA_Finalization(gt *testing.T) {
 	require.Equal(t, uint64(36), a.sequencer.SyncStatus().FinalizedL2.Number)
 }
 
-// This test tests ethDA -> altDA -> ethDA finalization behavior, simulating a temp altDA failure.
+// This test tests altDA -> ethDA -> altDA finalization behavior, simulating a temp altDA failure.
 func TestAltDA_FinalizationAfterEthDAFailover(gt *testing.T) {
 	t := helpers.NewDefaultTesting(gt)
 	// we only print critical logs to be able to see the statusLogs

--- a/op-e2e/actions/helpers/l2_batcher.go
+++ b/op-e2e/actions/helpers/l2_batcher.go
@@ -309,6 +309,20 @@ func (s *L2Batcher) ReadNextOutputFrame(t Testing) []byte {
 	return data.Bytes()
 }
 
+func (s *L2Batcher) ActAltDAFailoverToEthDA(t Testing) {
+	if !s.l2BatcherCfg.UseAltDA {
+		t.Fatalf("cannot failover to ethda when already using ethda")
+	}
+	s.l2BatcherCfg.UseAltDA = false
+}
+
+func (s *L2Batcher) ActAltDAFallbackToAltDA(t Testing) {
+	if s.l2BatcherCfg.UseAltDA {
+		t.Fatalf("cannot fallback to altDA when already using altDA")
+	}
+	s.l2BatcherCfg.UseAltDA = true
+}
+
 // ActL2BatchSubmit constructs a batch tx from previous buffered L2 blocks, and submits it to L1
 func (s *L2Batcher) ActL2BatchSubmit(t Testing, txOpts ...func(tx *types.DynamicFeeTx)) {
 	s.ActL2BatchSubmitRaw(t, s.ReadNextOutputFrame(t), txOpts...)

--- a/op-e2e/e2eutils/setup.go
+++ b/op-e2e/e2eutils/setup.go
@@ -1,6 +1,7 @@
 package e2eutils
 
 import (
+	"log/slog"
 	"math/big"
 	"os"
 	"path"
@@ -50,6 +51,7 @@ type TestParams struct {
 	L1BlockTime         uint64
 	UseAltDA            bool
 	AllocType           config.AllocType
+	LogLevel            slog.Level
 }
 
 func MakeDeployParams(t require.TestingT, tp *TestParams) *DeployParams {
@@ -66,7 +68,7 @@ func MakeDeployParams(t require.TestingT, tp *TestParams) *DeployParams {
 	deployConfig.UseAltDA = tp.UseAltDA
 	ApplyDeployConfigForks(deployConfig)
 
-	logger := log.NewLogger(log.DiscardHandler())
+	logger := log.NewLogger(log.NewTerminalHandlerWithLevel(os.Stdout, tp.LogLevel, true))
 	require.NoError(t, deployConfig.Check(logger))
 	require.Equal(t, addresses.Batcher, deployConfig.BatchSenderAddress)
 	require.Equal(t, addresses.Proposer, deployConfig.L2OutputOracleProposer)


### PR DESCRIPTION
Closes DAINT-122

**Description**

When altda->ethda failover happens, the op-node's L2 finalized head completely stalls.

This PR consists of 2 commits:
1. test to show the behavior (fails on this commit)
2. fix damgr so that finalizedHead can keep advancing even after failover

**Tests**

First commit contains test that shows the buggy behavior. To run:
```
git checkout <COMMIT>
go test -run ^TestAltDA_FinalizationAfterEthDAFailover$ github.com/layr-labs/optimism/op-e2e/actions/altda
```

**Fix**

The problem with the damgr as it is is that
```
d.finalizedHead = d.state.lastPrunedCommitment
```
is always run no matter what. This means that finalization is always driven by altda commitments, but after failover, damgr stops seeing the commitments (because they arent altda commitments anymore). The fix in the second commit is to let the finalization be driven by L1 finalization when there are no altda commitments managed by the damgr.

NOTE: I don't fully understand the subtleties of the damgr and derivation pipeline interactions, so might be doing something wrong here... but seems sound to me, especially since it passes the test.

**Additional Context**
The test is a bit ugly currently (see TODO comment below). Someone with better understanding of op-node and event processing order would surely be able to help me clean this up. I use this patch for debugging event processing, in case this is of use to anyone:
```
diff --git a/op-e2e/actions/altda/altda_test.go b/op-e2e/actions/altda/altda_test.go
index 9d60f2fee..c6ef361d7 100644
--- a/op-e2e/actions/altda/altda_test.go
+++ b/op-e2e/actions/altda/altda_test.go
@@ -194,7 +194,7 @@ func (a *L2AltDA) ActNewL2Tx(t helpers.Testing) {
 //
 // 17 makes sense because challengeWindow=16 and we create 1 extra block before that,
 // and 204 L2blocks = 17 L1blocks * 12 L2blocks/L1block (L1blocktime=12s, L2blocktime=1s)
-func (a *L2AltDA) ActNewL2TxFinalized(t helpers.Testing) {
+func (a *L2AltDA) ActNewL2TxFinalized(t helpers.Testing, logEvents ...bool) {
 	// Include a new l2 batcher transaction, submitting an input commitment to the l1.
 	a.ActNewL2Tx(t)
 	// Create ChallengeWindow empty blocks so the above batcher blocks can finalize (can't be challenged anymore)
@@ -203,7 +203,20 @@ func (a *L2AltDA) ActNewL2TxFinalized(t helpers.Testing) {
 	// TODO: understand why we need to drain the pipeline before AND after actL1Finalized
 	a.sequencer.ActL2PipelineFull(t)
 	a.ActL1Finalized(t)
-	a.sequencer.ActL2PipelineFull(t)
+	if logEvents == nil {
+		a.sequencer.ActL2PipelineFull(t)
+	} else {
+		// Log all events until the end of the pipeline
+		count := 0
+		a.sequencer.ActL2EventsUntil(t, func(ev event.Event) bool {
+			count++
+			a.log.Info("new event", "event", ev, "count", count)
+			if count == 100 {
+				return true
+			}
+			return false
+		}, 100, false)
+	}
 
 	// Uncomment the below code to observe the behavior described in the TODO above
 	// syncStatus := a.sequencer.SyncStatus()
@@ -680,5 +693,12 @@ func TestAltDA_FinalizationAfterEthDAFailover(gt *testing.T) {
 		ssAfter := harness.sequencer.SyncStatus()
 		// Even after failover, the finalized head should continue advancing normally
 		require.Equal(t, ssBefore.FinalizedL2.Number+diffL2Blocks, ssAfter.FinalizedL2.Number)
+
+		harness.log.Info("Sync status before",
+			"unsafeL1", ssBefore.HeadL1.Number, "safeL1", ssBefore.SafeL1.Number, "finalizedL1", ssBefore.FinalizedL1.Number,
+			"unsafeL2", ssBefore.UnsafeL2.Number, "safeL2", ssBefore.SafeL2.Number, "finalizedL2", ssBefore.FinalizedL2.Number)
+		harness.log.Info("Sync status after",
+			"unsafeL1", ssAfter.HeadL1.Number, "safeL1", ssAfter.SafeL1.Number, "finalizedL1", ssAfter.FinalizedL1.Number,
+			"unsafeL2", ssAfter.UnsafeL2.Number, "safeL2", ssAfter.SafeL2.Number, "finalizedL2", ssAfter.FinalizedL2.Number)
 	}
 }
```