### PR TITLE
test(kt-devnet): add batcher failover kurtosis test

### DIFF
--- a/.github/workflows/kurtosis-devnet.yml
+++ b/.github/workflows/kurtosis-devnet.yml
@@ -47,3 +47,5 @@ jobs:
           experimental: true
       - run: just eigenda-memstore-devnet-start
         working-directory: kurtosis-devnet
+      - run: just eigenda-memstore-devnet-test
+        working-directory: kurtosis-devnet

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.7
 
 require (
 	github.com/BurntSushi/toml v1.4.0
+	github.com/Layr-Labs/eigenda-proxy/clients v1.0.1
 	github.com/andybalholm/brotli v1.1.0
 	github.com/bmatcuk/doublestar/v4 v4.8.1
 	github.com/btcsuite/btcd v0.24.2

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e h1:ZIWapoIRN1VqT8GR8jAwb1Ie9GyehWjVcGh32Y2MznE=
 github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/Layr-Labs/eigenda-proxy/clients v1.0.1 h1:62NFB1fUauwQPGvTiOXhz1HKaL0fRhGy34tI9EpKz6I=
+github.com/Layr-Labs/eigenda-proxy/clients v1.0.1/go.mod h1:JbDNvSritUGHErvzwB5Tb1IrVk7kea9DSBLKEOkBebE=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/kurtosis-devnet/eigenda-memstore.yaml
+++ b/kurtosis-devnet/eigenda-memstore.yaml
@@ -68,8 +68,7 @@ optimism_package:
         cannon_prestates_url: "http://fileserver/proofs/op-program/cannon"
         extra_params: []
       da_server_params:
-        # TODO: release 1.6.5 which has memstore API routes
-        image: ghcr.io/layr-labs/eigenda-proxy:dev
+        image: ghcr.io/layr-labs/eigenda-proxy:v1.6.5
         cmd:
           - --addr
           - 0.0.0.0

--- a/kurtosis-devnet/eigenda-memstore.yaml
+++ b/kurtosis-devnet/eigenda-memstore.yaml
@@ -51,7 +51,7 @@ optimism_package:
         image: {{ localDockerImage "op-batcher" }}
         extra_params:
           - --altda.max-concurrent-da-requests=1
-          - --max-channel-duration=25
+          - --max-channel-duration=2
           - --target-num-frames=1
           - --max-l1-tx-size-bytes=1000
           - --batch-type=1
@@ -68,7 +68,8 @@ optimism_package:
         cannon_prestates_url: "http://fileserver/proofs/op-program/cannon"
         extra_params: []
       da_server_params:
-        image: ghcr.io/layr-labs/eigenda-proxy:v1.6.4
+        # TODO: release 1.6.5 which has memstore API routes
+        image: ghcr.io/layr-labs/eigenda-proxy:dev
         cmd:
           - --addr
           - 0.0.0.0
@@ -86,6 +87,8 @@ optimism_package:
 ethereum_package:
   participants:
     - el_type: geth
+      el_extra_params:
+        - --graphql # needed to query for batcher-inbox txs to test failover working correctly
       cl_type: teku
   network_params:
     preset: minimal

--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -155,10 +155,13 @@ eigenda-memstore-devnet-restart-batcher:
       --altda.da-server=http://da-server-op-kurtosis:3100 \
       --altda.da-service \
       --altda.max-concurrent-da-requests=1 \
-      --max-channel-duration=25 \
+      --max-channel-duration=2 \
       --target-num-frames=1 \
       --max-l1-tx-size-bytes=1000 \
       --batch-type=1
+[group('eigenda')]
+eigenda-memstore-devnet-test:
+    go test ./tests/eigenda/...
 
 # Simple devnet
 simple-devnet: (devnet "simple.yaml")

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -101,7 +101,7 @@ func TestFailover(t *testing.T) {
 // Test Harness, which contains all the state needed to run the tests.
 // harness also defines some higher-level "require" methods that are used in the tests.
 type harness struct {
-	endpoints           *EnclaveServiceEndpoints
+	endpoints           *EnclaveServicePublicEndpoints
 	clients             *EnclaveServiceClients
 	batchInboxAddr      common.Address
 	testStartL1BlockNum uint64
@@ -120,7 +120,7 @@ func newHarness(t *testing.T) *harness {
 	enclaveCtx, err := kurtosisCtx.GetEnclaveContext(ctxWithTimeout, enclaveName)
 	require.NoError(t, err, "Error getting enclave context: is enclave %v running?", enclaveName)
 
-	endpoints, err := getEndpointsFromKurtosis(enclaveCtx)
+	endpoints, err := getPublicEndpointsFromKurtosis(enclaveCtx)
 	require.NoError(t, err)
 	t.Logf("Endpoints: %+v", endpoints)
 
@@ -298,8 +298,11 @@ func fetchBatcherTxs(gethL1Endpoint string, batchInbox string, fromBlockNum, toB
 }
 
 // Localhost endpoints for the different services in the enclave
-// that we need to interact with.
-type EnclaveServiceEndpoints struct {
+// that we need to interact with. We store the public localhost endpoints instead
+// of the private enclave endpoints because we need to interact with the services
+// using external shell commands like `cast rpc ...` and `cast geth ...`.
+// The public endpoints are the ones that are exposed to the host machine.
+type EnclaveServicePublicEndpoints struct {
 	OpNodeEndpoint       string `kurtosis:"op-cl-1-op-node-op-geth-op-kurtosis,http"`
 	GethL1Endpoint       string `kurtosis:"el-1-geth-teku,rpc"`
 	EigendaProxyEndpoint string `kurtosis:"da-server-op-kurtosis,http"`
@@ -307,8 +310,14 @@ type EnclaveServiceEndpoints struct {
 	// NewServiceEndpoint   string `kurtosis:"new-service-name,port-name"`
 }
 
-func getEndpointsFromKurtosis(enclaveCtx *enclaves.EnclaveContext) (*EnclaveServiceEndpoints, error) {
-	endpoints := &EnclaveServiceEndpoints{}
+// Constructor for EnclaveServiceEndpoints struct, which assumes a running kurtosis enclave
+// and queries the needed services for their public (localhost) ports, and constructs
+// the struct with the endpoints.
+//
+// This function uses reflection to parse the `kurtosis` tags in the struct fields to get the service name and port name.
+// See the comments in the EnclaveServicePublicEndpoints struct for more details on adding a new endpoint.
+func getPublicEndpointsFromKurtosis(enclaveCtx *enclaves.EnclaveContext) (*EnclaveServicePublicEndpoints, error) {
+	endpoints := &EnclaveServicePublicEndpoints{}
 
 	// Get the type of the struct to iterate over fields
 	t := reflect.TypeOf(endpoints).Elem()
@@ -359,7 +368,7 @@ type EnclaveServiceClients struct {
 	proxyMemconfigClient *ProxyMemconfigClient
 }
 
-func getClientsFromEndpoints(endpoints *EnclaveServiceEndpoints) (*EnclaveServiceClients, error) {
+func getClientsFromEndpoints(endpoints *EnclaveServicePublicEndpoints) (*EnclaveServiceClients, error) {
 	opNodeClient, err := rpc.Dial(endpoints.OpNodeEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("rpc.Dial: %w", err)

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -190,8 +190,8 @@ const eigenDACommitmentPrefix = "0x010100"
 type DALayer string
 
 const (
-	DALayerEthCalldata     DALayer = "ethda-calldata"
-	DALayerEigenDA DALayer = "eigenda"
+	DALayerEthCalldata DALayer = "ethda-calldata"
+	DALayerEigenDA     DALayer = "eigenda"
 )
 
 type BatcherTx struct {

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -218,6 +218,10 @@ func (h *HexUint64) UnmarshalJSON(data []byte) error {
 }
 
 // Fetches all the batch-inbox posted commitments from blockNum (inclusive) to current block.
+// We rely on geth's GraphQL API to fetch the batcher transactions.
+// We could possibly have reused op-node's L1Retriever, but the API felt very derivation-pipeline specific,
+// and there doesn't seem to be a way to reuse it easily for constructing a custom derivation-pipeline with a subset of stages
+// like what we need here. Could consider migrating in the future if we need more complex logic.
 func fetchBatcherTxs(gethL1Endpoint string, batchInbox string, fromBlockNum, toBlockNum uint64) ([]BatcherTx, error) {
 	// We use standard HTTP for GraphQL as it's not directly supported by the rpc package
 	// Visit gethL1Endpoint/graphql/ui to see the schema and test queries

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -52,39 +52,49 @@ func TestFailover(t *testing.T) {
 		}
 	})
 
-	// assume kurtosis is running and is at least at block 10 (just deploying the contracts takes more than 10 blocks)
-	require.GreaterOrEqual(t, harness.testStartL1BlockNum, uint64(10), "Test started too early in the chain")
-	sinceBlock := harness.testStartL1BlockNum - 10
+	// Number of blocks to queried for batcher txs, for each of the initial/failover/failback stages
+	// Test will look at batcher txs between blocks:
+	// - initial altda stage: [testStartL1BlockNum - l1BlocksQueriedForBatcherTxs, testStartL1BlockNum]
+	// - ethDACalldata stage: [afterFailoverFromBlockNum, afterFailoverFromBlockNum + l1BlocksQueriedForBatcherTxs]
+	// - altDA stage: [afterFailbackFromBlockNum, afterFailbackFromBlockNum + l1BlocksQueriedForBatcherTxs]
+	//
+	// After Failover/Failback, will wait for 10 L1 blocks to make sure failover/failback has happened.
+	// Assumption is that a cert is being posted every 2 blocks (hardcoded in batcher config)
+	// TODO: read max-channel-duration from batcher's config instead of assuming 2 blocks
+	l1BlocksQueriedForBatcherTxs := uint64(10)
+
+	// assume kurtosis is running and is at least at block numBlocksBetweenStages
+	require.GreaterOrEqual(t, harness.testStartL1BlockNum, l1BlocksQueriedForBatcherTxs, "Test started too early in the chain")
+	fromBlock := harness.testStartL1BlockNum - l1BlocksQueriedForBatcherTxs
 
 	// 1. Check that the original commitments are EigenDA
-	harness.requireBatcherTxsToBeFromLayer(t, sinceBlock, DALayerEigenDA)
+	harness.requireBatcherTxsToBeFromLayer(t, fromBlock, fromBlock+l1BlocksQueriedForBatcherTxs, DALayerEigenDA)
 
 	// 2. Failover and check that the commitments are now EthDA
 	t.Logf("Failover over... changing proxy's config to return 503 errors")
 	err := harness.clients.proxyMemconfigClient.Failover(ctxWithDeadline)
 	require.NoError(t, err)
 
-	afterFailoverL1BlockNum, err := harness.clients.gethL1Client.BlockNumber(ctxWithDeadline)
+	afterFailoverFromBlockNum, err := harness.clients.gethL1Client.BlockNumber(ctxWithDeadline)
 	require.NoError(t, err)
-	// Wait for 10 L1 blocks. Assumption is that a cert is being posted every 2 blocks.
-	// Failover should take some time so we wait for 10 blocks to be sure some new commitment has started getting posted.
-	// TODO: read max-channel-duration from batcher's config instead of assuming 2 blocks
-	_, err = geth.WaitForBlock(big.NewInt(int64(afterFailoverL1BlockNum)+10), harness.clients.gethL1Client)
+	afterFailoverToBlockNum := afterFailoverFromBlockNum + l1BlocksQueriedForBatcherTxs
+	_, err = geth.WaitForBlock(big.NewInt(int64(afterFailoverToBlockNum)), harness.clients.gethL1Client)
 	require.NoError(t, err)
 
-	harness.requireBatcherTxsToBeFromLayer(t, afterFailoverL1BlockNum, DALayerEth)
+	harness.requireBatcherTxsToBeFromLayer(t, afterFailoverFromBlockNum, afterFailoverToBlockNum, DALayerEth)
 
 	// 3. Failback and check that the commitments are EigenDA again
 	t.Logf("Failing back... changing proxy's config to start processing PUT requests normally again")
 	err = harness.clients.proxyMemconfigClient.Failback(ctxWithDeadline)
 	require.NoError(t, err)
 
-	afterFailbackL1BlockNum, err := harness.clients.gethL1Client.BlockNumber(ctxWithDeadline)
+	afterFailbackFromBlockNum, err := harness.clients.gethL1Client.BlockNumber(ctxWithDeadline)
 	require.NoError(t, err)
-	_, err = geth.WaitForBlock(big.NewInt(int64(afterFailbackL1BlockNum)+10), harness.clients.gethL1Client)
+	afterFailbackToBlockNum := afterFailbackFromBlockNum + l1BlocksQueriedForBatcherTxs
+	_, err = geth.WaitForBlock(big.NewInt(int64(afterFailbackToBlockNum)), harness.clients.gethL1Client)
 	require.NoError(t, err)
 
-	harness.requireBatcherTxsToBeFromLayer(t, afterFailbackL1BlockNum, DALayerEigenDA)
+	harness.requireBatcherTxsToBeFromLayer(t, afterFailbackFromBlockNum, afterFailbackToBlockNum, DALayerEigenDA)
 
 }
 
@@ -139,10 +149,10 @@ func newHarness(t *testing.T) *harness {
 // requireBatcherTxsToBeFromLayer checks that the batcher transactions since startingFromBlockNum are all from the expectedLayer.
 // It allows for up to 3 initial commitments to be of the wrong type, as the failover/failback might not have taken effect yet.
 // It requires that at least 2 commitments of the expected type are present after the failover/failback.
-func (h *harness) requireBatcherTxsToBeFromLayer(t *testing.T, startingFromBlockNum uint64, expectedLayer DALayer) {
-	batcherTxs, err := fetchBatcherTxsSinceBlock(h.endpoints.GethL1Endpoint, h.batchInboxAddr.String(), startingFromBlockNum)
+func (h *harness) requireBatcherTxsToBeFromLayer(t *testing.T, fromBlockNum, toBlockNum uint64, expectedLayer DALayer) {
+	batcherTxs, err := fetchBatcherTxs(h.endpoints.GethL1Endpoint, h.batchInboxAddr.String(), fromBlockNum, toBlockNum)
 	require.NoError(t, err)
-	t.Logf("Fetched %d batcher transactions since block %d", len(batcherTxs), startingFromBlockNum)
+	t.Logf("Fetched %d batcher transactions since block %d", len(batcherTxs), fromBlockNum)
 
 	// We allow first 3 commitments to be of the wrong DA layer, as the failover/failback might not have taken effect yet.
 	wrongCommitmentsToDiscard := 0
@@ -209,12 +219,13 @@ func (h *HexUint64) UnmarshalJSON(data []byte) error {
 }
 
 // Fetches all the batch-inbox posted commitments from blockNum (inclusive) to current block.
-func fetchBatcherTxsSinceBlock(gethL1Endpoint string, batchInbox string, blockNum uint64) ([]BatcherTx, error) {
-	// We'll use standard HTTP for GraphQL as it's not directly supported by the rpc package
+func fetchBatcherTxs(gethL1Endpoint string, batchInbox string, fromBlockNum, toBlockNum uint64) ([]BatcherTx, error) {
+	// We use standard HTTP for GraphQL as it's not directly supported by the rpc package
+	// Visit gethL1Endpoint/graphql/ui to see the schema and test queries
 	query := fmt.Sprintf(`
 	{
-		"query": "query txInfo { blocks(from:%v) { transactions { to { address } inputData block { number } } } }"
-	}`, blockNum)
+		"query": "query txInfo { blocks(from:%v, to:%v) { transactions { to { address } inputData block { number } } } }"
+	}`, fromBlockNum, toBlockNum)
 
 	// Make GraphQL request
 	req, err := http.NewRequest("POST", gethL1Endpoint+"/graphql", strings.NewReader(query))

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -321,7 +321,7 @@ func getEndpointsFromKurtosis(enclaveCtx *enclaves.EnclaveContext) (*EnclaveServ
 		// Get the kurtosis tag
 		tag := field.Tag.Get("kurtosis")
 		if tag == "" {
-			continue // Skip fields without tags
+			return nil, fmt.Errorf("field %s doesn't have a kurtosis tag", field.Name)
 		}
 
 		// Parse the tag to get service name and port name

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -91,7 +91,6 @@ func TestFailover(t *testing.T) {
 // Test Harness, which contains all the state needed to run the tests.
 // harness also defines some higher-level "require" methods that are used in the tests.
 type harness struct {
-	enclaveCtx          *enclaves.EnclaveContext
 	endpoints           *EnclaveServiceEndpoints
 	clients             *EnclaveServiceClients
 	batchInboxAddr      common.Address
@@ -130,7 +129,6 @@ func newHarness(t *testing.T) *harness {
 	require.NoError(t, err)
 
 	return &harness{
-		enclaveCtx:          enclaveCtx,
 		endpoints:           endpoints,
 		clients:             clients,
 		batchInboxAddr:      common.HexToAddress(rollupConfigMap.BatchInboxAddress),

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -1,0 +1,398 @@
+package eigenda_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Layr-Labs/eigenda-proxy/clients/memconfig_client"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/enclaves"
+	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
+	"github.com/stretchr/testify/require"
+)
+
+// All tests are run in the context of the eigenda-memstore-devnet enclave.
+// We assume that this enclave is already running.
+const enclaveName = "eigenda-memstore-devnet"
+
+func TestFailover(t *testing.T) {
+	deadline, ok := t.Deadline()
+	if !ok {
+		deadline = time.Now().Add(1 * time.Minute)
+	}
+	ctxWithDeadline, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	harness := newHarness(t)
+	t.Cleanup(func() {
+		// switch proxy back to normal mode, in case test gets cancelled
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		err := harness.clients.proxyMemconfigClient.Failback(ctx)
+		if err != nil {
+			t.Logf("Error failing back... you might need to reset proxy to normal mode manually: %v", err)
+		}
+	})
+
+	// assume kurtosis is running and is at least at block 10 (just deploying the contracts takes more than 10 blocks)
+	require.GreaterOrEqual(t, harness.testStartL1BlockNum, uint64(10), "Test started too early in the chain")
+	sinceBlock := harness.testStartL1BlockNum - 10
+
+	// 1. Check that the original commitments are EigenDA
+	harness.requireBatcherTxsToBeFromLayer(t, sinceBlock, DALayerEigenDA)
+
+	// 2. Failover and check that the commitments are now EthDA
+	err := harness.clients.proxyMemconfigClient.Failover(ctxWithDeadline)
+	require.NoError(t, err)
+
+	afterFailoverL1BlockNum, err := harness.clients.gethL1Client.BlockNumber(ctxWithDeadline)
+	require.NoError(t, err)
+	// Wait for 10 L1 blocks. Assumption is that a cert is being posted every 2 blocks.
+	// Failover should take some time so we wait for 10 blocks to be sure some new commitment has started getting posted.
+	// TODO: read max-channel-duration from batcher's config instead of assuming 2 blocks
+	_, err = geth.WaitForBlock(big.NewInt(int64(afterFailoverL1BlockNum)+10), harness.clients.gethL1Client)
+	require.NoError(t, err)
+
+	harness.requireBatcherTxsToBeFromLayer(t, afterFailoverL1BlockNum, DALayerEth)
+
+	// 3. Failback and check that the commitments are EigenDA again
+	err = harness.clients.proxyMemconfigClient.Failback(ctxWithDeadline)
+	require.NoError(t, err)
+
+	afterFailbackL1BlockNum, err := harness.clients.gethL1Client.BlockNumber(ctxWithDeadline)
+	require.NoError(t, err)
+	_, err = geth.WaitForBlock(big.NewInt(int64(afterFailbackL1BlockNum)+10), harness.clients.gethL1Client)
+	require.NoError(t, err)
+
+	harness.requireBatcherTxsToBeFromLayer(t, afterFailbackL1BlockNum, DALayerEigenDA)
+
+}
+
+// Test Harness, which contains all the state needed to run the tests.
+// harness also defines some higher-level "require" methods that are used in the tests.
+type harness struct {
+	enclaveCtx          *enclaves.EnclaveContext
+	endpoints           *EnclaveServiceEndpoints
+	clients             *EnclaveServiceClients
+	batchInboxAddr      common.Address
+	testStartL1BlockNum uint64
+}
+
+func newHarness(t *testing.T) *harness {
+	// We leave 20 seconds to build the entire testHarness.
+	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// Create a Kurtosis context
+	kurtosisCtx, err := kurtosis_context.NewKurtosisContextFromLocalEngine()
+	require.NoError(t, err)
+
+	// Get the eigenda-memstore-devnet enclave (assuming it's already running)
+	enclaveCtx, err := kurtosisCtx.GetEnclaveContext(ctxWithTimeout, enclaveName)
+	require.NoError(t, err, "Error getting enclave context: is enclave %v running?", enclaveName)
+
+	endpoints, err := getEndpointsFromKurtosis(enclaveCtx)
+	require.NoError(t, err)
+	t.Logf("Endpoints: %+v", endpoints)
+
+	clients, err := getClientsFromEndpoints(endpoints)
+	require.NoError(t, err)
+
+	// Get the batch inbox address
+	var rollupConfigMap struct {
+		BatchInboxAddress string `json:"batch_inbox_address"`
+	}
+	err = clients.opNodeClient.CallContext(ctxWithTimeout, &rollupConfigMap, "optimism_rollupConfig")
+	require.NoError(t, err)
+
+	// Get the current L1 block number
+	testStartL1BlockNum, err := clients.gethL1Client.BlockNumber(ctxWithTimeout)
+	require.NoError(t, err)
+
+	return &harness{
+		enclaveCtx:          enclaveCtx,
+		endpoints:           endpoints,
+		clients:             clients,
+		batchInboxAddr:      common.HexToAddress(rollupConfigMap.BatchInboxAddress),
+		testStartL1BlockNum: testStartL1BlockNum,
+	}
+}
+
+// requireBatcherTxsToBeFromLayer checks that the batcher transactions since startingFromBlockNum are all from the expectedLayer.
+// It allows for up to 3 initial commitments to be of the wrong type, as the failover/failback might not have taken effect yet.
+// It requires that at least 2 commitments of the expected type are present after the failover/failback.
+func (h *harness) requireBatcherTxsToBeFromLayer(t *testing.T, startingFromBlockNum uint64, expectedLayer DALayer) {
+	batcherTxs, err := fetchBatcherTxsSinceBlock(h.endpoints.GethL1Endpoint, h.batchInboxAddr.String(), startingFromBlockNum)
+	require.NoError(t, err)
+
+	// We allow first 3 commitments to be of the wrong DA layer, as the failover/failback might not have taken effect yet.
+	ethDACommitmentsToDiscard := 0
+	for _, batcherTx := range batcherTxs {
+		if batcherTx.daLayer == DALayerEth {
+			ethDACommitmentsToDiscard++
+		}
+		// as soon as we see 3 ethDA commitments, or an EigenDA commitment, we stop
+		// We expect every other commitment to be EigenDA after failback
+		if ethDACommitmentsToDiscard > 2 || batcherTx.daLayer == DALayerEigenDA {
+			break
+		}
+	}
+	batcherTxs = batcherTxs[ethDACommitmentsToDiscard:]
+
+	// After potentially discarding up to 3 commitments, we expect all future commitments (at least 2) to be of the expectedLayer
+	require.GreaterOrEqual(t, len(batcherTxs), 2, "Expected at least 2 %v commitments after failover/failback", expectedLayer)
+	for _, batcherTx := range batcherTxs {
+		require.Equal(t, DALayerEigenDA, batcherTx.daLayer,
+			"Invalid commitment in block %d: expected %v, received commitment %s", batcherTx.block, expectedLayer, batcherTx.commitment)
+	}
+}
+
+// See https://specs.optimism.io/experimental/alt-da.html#example-commitments
+const ethDACommitmentPrefix = "0x00"
+const eigenDACommitmentPrefix = "0x010100"
+
+type DALayer string
+
+const (
+	DALayerEth     DALayer = "ethda"
+	DALayerEigenDA DALayer = "eigenda"
+)
+
+type BatcherTx struct {
+	commitment string
+	daLayer    DALayer // commitment starts with respective prefix
+	block      uint64
+}
+
+// HexUint64 is a custom type that can unmarshal from a hex string
+type HexUint64 uint64
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (h *HexUint64) UnmarshalJSON(data []byte) error {
+	// Remove quotes from the JSON string
+	hexStr := string(data)
+	hexStr = strings.Trim(hexStr, "\"")
+
+	// Check if it's a hex string
+	if !strings.HasPrefix(hexStr, "0x") {
+		return fmt.Errorf("not a hex string: %s", hexStr)
+	}
+
+	// Parse the hex string (without the 0x prefix)
+	val, err := strconv.ParseUint(hexStr[2:], 16, 64)
+	if err != nil {
+		return err
+	}
+
+	*h = HexUint64(val)
+	return nil
+}
+
+// Fetches all the batch-inbox posted commitments from blockNum (inclusive) to current block.
+func fetchBatcherTxsSinceBlock(gethL1Endpoint string, batchInbox string, blockNum uint64) ([]BatcherTx, error) {
+	// We'll use standard HTTP for GraphQL as it's not directly supported by the rpc package
+	query := fmt.Sprintf(`
+	{
+		"query": "query txInfo { blocks(from:%v) { transactions { to { address } inputData block { number } } } }"
+	}`, blockNum)
+
+	// Make GraphQL request
+	req, err := http.NewRequest("POST", gethL1Endpoint+"/graphql", strings.NewReader(query))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Parse the response
+	type GraphQLResponse struct {
+		Data struct {
+			Blocks []struct {
+				Transactions []struct {
+					To struct {
+						Address string `json:"address"`
+					} `json:"to"`
+					InputData string `json:"inputData"`
+					Block     struct {
+						// we use HexUint64 to properly parse the hex strings returned
+						Number HexUint64 `json:"number"`
+					} `json:"block"`
+				} `json:"transactions"`
+			} `json:"blocks"`
+		} `json:"data"`
+	}
+	var graphQLResp GraphQLResponse
+	if err := json.NewDecoder(resp.Body).Decode(&graphQLResp); err != nil {
+		return nil, err
+	}
+	if len(graphQLResp.Data.Blocks) == 0 {
+		// Assume that this is a graphQL query error, that would have returned something like
+		// "errors": [
+		// 	{
+		// 	  "message": "syntax error: unexpected \"\", expecting Ident",
+		// 	}
+		// ]
+		// TODO: prob should just switch to a proper graphql client that can handle these properly
+		return nil, fmt.Errorf("no blocks returned in GraphQL response")
+	}
+
+	// Filter transactions to the batcher address
+	var batcherTxs []BatcherTx
+	for _, block := range graphQLResp.Data.Blocks {
+		for _, tx := range block.Transactions {
+			if strings.EqualFold(tx.To.Address, batchInbox) {
+				var daLayer DALayer
+				if strings.HasPrefix(tx.InputData, eigenDACommitmentPrefix) {
+					daLayer = DALayerEigenDA
+				} else if strings.HasPrefix(tx.InputData, ethDACommitmentPrefix) {
+					daLayer = DALayerEth
+				} else {
+					return nil, fmt.Errorf("unknown commitment prefix: %s", tx.InputData)
+				}
+				batcherTxs = append(batcherTxs, BatcherTx{
+					commitment: tx.InputData,
+					daLayer:    daLayer,
+					block:      uint64(tx.Block.Number),
+				})
+			}
+		}
+	}
+
+	return batcherTxs, nil
+}
+
+// Localhost endpoints for the different services in the enclave
+// that we need to interact with.
+type EnclaveServiceEndpoints struct {
+	OpNodeEndpoint       string `kurtosis:"op-cl-1-op-node-op-geth-op-kurtosis,http"`
+	GethL1Endpoint       string `kurtosis:"el-1-geth-teku,rpc"`
+	EigendaProxyEndpoint string `kurtosis:"da-server-op-kurtosis,http"`
+	// Adding new endpoints is as simple as adding a new field with a kurtosis tag
+	// NewServiceEndpoint   string `kurtosis:"new-service-name,port-name"`
+}
+
+func getEndpointsFromKurtosis(enclaveCtx *enclaves.EnclaveContext) (*EnclaveServiceEndpoints, error) {
+	endpoints := &EnclaveServiceEndpoints{}
+
+	// Get the type of the struct to iterate over fields
+	t := reflect.TypeOf(endpoints).Elem()
+	v := reflect.ValueOf(endpoints).Elem()
+
+	// Iterate over all fields in the struct
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		// Get the kurtosis tag
+		tag := field.Tag.Get("kurtosis")
+		if tag == "" {
+			continue // Skip fields without tags
+		}
+
+		// Parse the tag to get service name and port name
+		parts := strings.Split(tag, ",")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid kurtosis tag format for field %s: %s", field.Name, tag)
+		}
+
+		serviceName := parts[0]
+		portName := parts[1]
+
+		// Get the service context
+		serviceCtx, err := enclaveCtx.GetServiceContext(serviceName)
+		if err != nil {
+			return nil, fmt.Errorf("GetServiceContext for %s: %w", serviceName, err)
+		}
+
+		// Get the port
+		port, ok := serviceCtx.GetPublicPorts()[portName]
+		if !ok {
+			return nil, fmt.Errorf("service %s doesn't expose %s port", serviceName, portName)
+		}
+
+		// Set the endpoint URL in the struct field
+		endpoint := fmt.Sprintf("http://localhost:%d", port.GetNumber())
+		v.Field(i).SetString(endpoint)
+	}
+
+	return endpoints, nil
+}
+
+type EnclaveServiceClients struct {
+	opNodeClient         *rpc.Client
+	gethL1Client         *ethclient.Client
+	proxyMemconfigClient *ProxyMemconfigClient
+}
+
+func getClientsFromEndpoints(endpoints *EnclaveServiceEndpoints) (*EnclaveServiceClients, error) {
+	opNodeClient, err := rpc.Dial(endpoints.OpNodeEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("rpc.Dial: %w", err)
+	}
+
+	gethL1Client, err := ethclient.Dial(endpoints.GethL1Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("ethclient.Dial: %w", err)
+	}
+
+	proxyMemconfigClient := &ProxyMemconfigClient{
+		Client: memconfig_client.New(&memconfig_client.Config{URL: endpoints.EigendaProxyEndpoint}),
+	}
+
+	return &EnclaveServiceClients{
+		opNodeClient:         opNodeClient,
+		gethL1Client:         gethL1Client,
+		proxyMemconfigClient: proxyMemconfigClient,
+	}, nil
+}
+
+// ProxyMemconfigClient is a wrapper around the memconfig client that adds a Failover method
+// TODO: we should upstream this to eigenda-proxy repo
+type ProxyMemconfigClient struct {
+	*memconfig_client.Client
+}
+
+// Update the proxy's memstore config to start returning 503 errors
+// Note: we have to GetConfig, update it and then UpdateConfig because the client doesn't implement a "patch" method,
+//
+//	even though the API does support it.
+func (c *ProxyMemconfigClient) Failover(ctx context.Context) error {
+	memConfig, err := c.GetConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("GetConfig: %w", err)
+	}
+	memConfig.PutReturnsFailoverError = true
+	_, err = c.UpdateConfig(ctx, memConfig)
+	if err != nil {
+		return fmt.Errorf("UpdateConfig: %w", err)
+	}
+	return nil
+}
+func (c *ProxyMemconfigClient) Failback(ctx context.Context) error {
+	memConfig, err := c.GetConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("GetConfig: %w", err)
+	}
+	memConfig.PutReturnsFailoverError = false
+	_, err = c.UpdateConfig(ctx, memConfig)
+	if err != nil {
+		return fmt.Errorf("UpdateConfig: %w", err)
+	}
+	return nil
+}

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -29,7 +29,7 @@ const enclaveName = "eigenda-memstore-devnet"
 // TestFailover tests the failover behavior of the batcher, in response to the proxy returning 503 errors.
 // See https://github.com/Layr-Labs/eigenda-proxy?tab=readme-ov-file#failover-signals for proxy behavior.
 // The proxy's memstore's failover behavior is toggled on and off by this test via a REST api.
-// We then check that the batcher correctly interprets the 503 signals and starts submitting batches to EthDA instead.
+// We then check that the batcher correctly interprets the 503 signals and starts submitting batches to EthDACalldata instead.
 // The test then toggles the failover back off and checks that the batcher starts submitting EigenDA batches again.
 // The batches inbox transactions are queried via geth's GraphQL API.
 //
@@ -37,7 +37,7 @@ const enclaveName = "eigenda-memstore-devnet"
 // That is, if we ever implement more kurtosis tests, they would currently need to be run sequentially.
 //
 // TODO: We will also need to test the failover behavior of the node, which currently doesn't finalize after failover (fixed in https://github.com/Layr-Labs/optimism/pull/23)
-func TestFailover(t *testing.T) {
+func TestFailoverToEthDACalldata(t *testing.T) {
 	deadline, ok := t.Deadline()
 	if !ok {
 		deadline = time.Now().Add(1 * time.Minute)
@@ -74,7 +74,7 @@ func TestFailover(t *testing.T) {
 	// 1. Check that the original commitments are EigenDA
 	harness.requireBatcherTxsToBeFromLayer(t, fromBlock, fromBlock+l1BlocksQueriedForBatcherTxs, DALayerEigenDA)
 
-	// 2. Failover and check that the commitments are now EthDA
+	// 2. Failover and check that the commitments are now EthDACalldata
 	t.Logf("Failover over... changing proxy's config to return 503 errors")
 	err := harness.clients.proxyMemconfigClient.Failover(ctxWithDeadline)
 	require.NoError(t, err)
@@ -85,7 +85,7 @@ func TestFailover(t *testing.T) {
 	_, err = geth.WaitForBlock(big.NewInt(int64(afterFailoverToBlockNum)), harness.clients.gethL1Client)
 	require.NoError(t, err)
 
-	harness.requireBatcherTxsToBeFromLayer(t, afterFailoverFromBlockNum, afterFailoverToBlockNum, DALayerEth)
+	harness.requireBatcherTxsToBeFromLayer(t, afterFailoverFromBlockNum, afterFailoverToBlockNum, DALayerEthCalldata)
 
 	// 3. Failback and check that the commitments are EigenDA again
 	t.Logf("Failing back... changing proxy's config to start processing PUT requests normally again")
@@ -181,13 +181,16 @@ func (h *harness) requireBatcherTxsToBeFromLayer(t *testing.T, fromBlockNum, toB
 }
 
 // See https://specs.optimism.io/experimental/alt-da.html#example-commitments
-const ethDACommitmentPrefix = "0x00"
+// Batcher only supports failing over to calldata txs right now, so this test doesn't test 4844 failover.
+// Note that 4844 txs are completely different and don't use normal txs with a prefix in the calldata,
+// see https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/derive/blob_data_source.go#L134-L137
+const ethDACalldataCommitmentPrefix = "0x00"
 const eigenDACommitmentPrefix = "0x010100"
 
 type DALayer string
 
 const (
-	DALayerEth     DALayer = "ethda"
+	DALayerEthCalldata     DALayer = "ethda-calldata"
 	DALayerEigenDA DALayer = "eigenda"
 )
 
@@ -288,8 +291,8 @@ func fetchBatcherTxs(gethL1Endpoint string, batchInbox string, fromBlockNum, toB
 				var daLayer DALayer
 				if strings.HasPrefix(tx.InputData, eigenDACommitmentPrefix) {
 					daLayer = DALayerEigenDA
-				} else if strings.HasPrefix(tx.InputData, ethDACommitmentPrefix) {
-					daLayer = DALayerEth
+				} else if strings.HasPrefix(tx.InputData, ethDACalldataCommitmentPrefix) {
+					daLayer = DALayerEthCalldata
 				} else {
 					return nil, fmt.Errorf("unknown commitment prefix: %s", tx.InputData)
 				}

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -32,6 +32,10 @@ const enclaveName = "eigenda-memstore-devnet"
 // We then check that the batcher correctly interprets the 503 signals and starts submitting batches to EthDA instead.
 // The test then toggles the failover back off and checks that the batcher starts submitting EigenDA batches again.
 // The batches inbox transactions are queried via geth's GraphQL API.
+//
+// Note: because this test relies on modifying the proxy's memstore config, it should be run in isolation.
+// That is, if we ever implement more kurtosis tests, they would currently need to be run sequentially.
+//
 // TODO: We will also need to test the failover behavior of the node, which currently doesn't finalize after failover (fixed in https://github.com/Layr-Labs/optimism/pull/23)
 func TestFailover(t *testing.T) {
 	deadline, ok := t.Deadline()

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -160,8 +160,7 @@ func (h *harness) requireBatcherTxsToBeFromLayer(t *testing.T, fromBlockNum, toB
 		if batcherTx.daLayer != expectedLayer {
 			wrongCommitmentsToDiscard++
 		}
-		// as soon as we see 3 ethDA commitments, or an EigenDA commitment, we stop
-		// We expect every other commitment to be EigenDA after failback
+		// as soon as we see a commitmentment from expectedLayer, or 3 from the other layer, we stop discarding.
 		if wrongCommitmentsToDiscard > 2 || batcherTx.daLayer == expectedLayer {
 			break
 		}

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -398,8 +398,7 @@ type ProxyMemconfigClient struct {
 
 // Update the proxy's memstore config to start returning 503 errors
 // Note: we have to GetConfig, update it and then UpdateConfig because the client doesn't implement a "patch" method,
-//
-//	even though the API does support it.
+// even though the API does support it.
 func (c *ProxyMemconfigClient) Failover(ctx context.Context) error {
 	memConfig, err := c.GetConfig(ctx)
 	if err != nil {

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -26,6 +26,13 @@ import (
 // We assume that this enclave is already running.
 const enclaveName = "eigenda-memstore-devnet"
 
+// TestFailover tests the failover behavior of the batcher, in response to the proxy returning 503 errors.
+// See https://github.com/Layr-Labs/eigenda-proxy?tab=readme-ov-file#failover-signals for proxy behavior.
+// The proxy's memstore's failover behavior is toggled on and off by this test via a REST api.
+// We then check that the batcher correctly interprets the 503 signals and starts submitting batches to EthDA instead.
+// The test then toggles the failover back off and checks that the batcher starts submitting EigenDA batches again.
+// The batches inbox transactions are queried via geth's GraphQL API.
+// TODO: We will also need to test the failover behavior of the node, which currently doesn't finalize after failover (fixed in https://github.com/Layr-Labs/optimism/pull/23)
 func TestFailover(t *testing.T) {
 	deadline, ok := t.Deadline()
 	if !ok {
@@ -53,6 +60,7 @@ func TestFailover(t *testing.T) {
 	harness.requireBatcherTxsToBeFromLayer(t, sinceBlock, DALayerEigenDA)
 
 	// 2. Failover and check that the commitments are now EthDA
+	t.Logf("Failover over... changing proxy's config to return 503 errors")
 	err := harness.clients.proxyMemconfigClient.Failover(ctxWithDeadline)
 	require.NoError(t, err)
 
@@ -67,6 +75,7 @@ func TestFailover(t *testing.T) {
 	harness.requireBatcherTxsToBeFromLayer(t, afterFailoverL1BlockNum, DALayerEth)
 
 	// 3. Failback and check that the commitments are EigenDA again
+	t.Logf("Failing back... changing proxy's config to start processing PUT requests normally again")
 	err = harness.clients.proxyMemconfigClient.Failback(ctxWithDeadline)
 	require.NoError(t, err)
 
@@ -135,25 +144,27 @@ func newHarness(t *testing.T) *harness {
 func (h *harness) requireBatcherTxsToBeFromLayer(t *testing.T, startingFromBlockNum uint64, expectedLayer DALayer) {
 	batcherTxs, err := fetchBatcherTxsSinceBlock(h.endpoints.GethL1Endpoint, h.batchInboxAddr.String(), startingFromBlockNum)
 	require.NoError(t, err)
+	t.Logf("Fetched %d batcher transactions since block %d", len(batcherTxs), startingFromBlockNum)
 
 	// We allow first 3 commitments to be of the wrong DA layer, as the failover/failback might not have taken effect yet.
-	ethDACommitmentsToDiscard := 0
+	wrongCommitmentsToDiscard := 0
 	for _, batcherTx := range batcherTxs {
-		if batcherTx.daLayer == DALayerEth {
-			ethDACommitmentsToDiscard++
+		if batcherTx.daLayer != expectedLayer {
+			wrongCommitmentsToDiscard++
 		}
 		// as soon as we see 3 ethDA commitments, or an EigenDA commitment, we stop
 		// We expect every other commitment to be EigenDA after failback
-		if ethDACommitmentsToDiscard > 2 || batcherTx.daLayer == DALayerEigenDA {
+		if wrongCommitmentsToDiscard > 2 || batcherTx.daLayer == expectedLayer {
 			break
 		}
 	}
-	batcherTxs = batcherTxs[ethDACommitmentsToDiscard:]
+	batcherTxs = batcherTxs[wrongCommitmentsToDiscard:]
+	t.Logf("Discarded %d commitments. %d left which should all be %v", wrongCommitmentsToDiscard, len(batcherTxs), expectedLayer)
 
 	// After potentially discarding up to 3 commitments, we expect all future commitments (at least 2) to be of the expectedLayer
 	require.GreaterOrEqual(t, len(batcherTxs), 2, "Expected at least 2 %v commitments after failover/failback", expectedLayer)
 	for _, batcherTx := range batcherTxs {
-		require.Equal(t, DALayerEigenDA, batcherTx.daLayer,
+		require.Equal(t, expectedLayer, batcherTx.daLayer,
 			"Invalid commitment in block %d: expected %v, received commitment %s", batcherTx.block, expectedLayer, batcherTx.commitment)
 	}
 }


### PR DESCRIPTION
Closes DAINT-303

This PR adds a golang failover test which uses the kurtosis devnet as backend.
This test is used to test the new batcher failover behavior from https://github.com/Layr-Labs/optimism/pull/34.
We will merge this test into that PR, and then that PR into eigenda-develop (our master branch).

### Note to reviewers

Please be very harsh on the golang test, as this same framework will be reused to add new tests for future features.

The "proper" way to implement this would probably have been to reuse op's [op-e2e framework](https://github.com/Layr-Labs/optimism/blob/8a1e07341d87afc923509920c2a54d1e9bd523f4/op-e2e/system/e2esys/setup.go#L349), but create a way to populate this system (equivalent to our harness in this PR) from a kurtosis backend. This would have taken me a lot more time to figure out however, and I feel like its something that the OP team might create at some point, so prefer to let them put in the work there and figure out how to do it properly, and we can potentially move to using that at a future point.