### PR TITLE
feat(batcher): altda->ethda failover

### DIFF
--- a/.github/workflows/kurtosis-devnet.yml
+++ b/.github/workflows/kurtosis-devnet.yml
@@ -47,3 +47,5 @@ jobs:
           experimental: true
       - run: just eigenda-memstore-devnet-start
         working-directory: kurtosis-devnet
+      - run: just eigenda-memstore-devnet-test
+        working-directory: kurtosis-devnet

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.7
 
 require (
 	github.com/BurntSushi/toml v1.4.0
+	github.com/Layr-Labs/eigenda-proxy/clients v1.0.1
 	github.com/andybalholm/brotli v1.1.0
 	github.com/bmatcuk/doublestar/v4 v4.8.1
 	github.com/btcsuite/btcd v0.24.2

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e h1:ZIWapoIRN1VqT8GR8jAwb1Ie9GyehWjVcGh32Y2MznE=
 github.com/DataDog/zstd v1.5.6-0.20230824185856-869dae002e5e/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/Layr-Labs/eigenda-proxy/clients v1.0.1 h1:62NFB1fUauwQPGvTiOXhz1HKaL0fRhGy34tI9EpKz6I=
+github.com/Layr-Labs/eigenda-proxy/clients v1.0.1/go.mod h1:JbDNvSritUGHErvzwB5Tb1IrVk7kea9DSBLKEOkBebE=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/kurtosis-devnet/eigenda-memstore.yaml
+++ b/kurtosis-devnet/eigenda-memstore.yaml
@@ -51,7 +51,7 @@ optimism_package:
         image: {{ localDockerImage "op-batcher" }}
         extra_params:
           - --altda.max-concurrent-da-requests=1
-          - --max-channel-duration=25
+          - --max-channel-duration=2
           - --target-num-frames=1
           - --max-l1-tx-size-bytes=1000
           - --batch-type=1
@@ -68,7 +68,7 @@ optimism_package:
         cannon_prestates_url: "http://fileserver/proofs/op-program/cannon"
         extra_params: []
       da_server_params:
-        image: ghcr.io/layr-labs/eigenda-proxy:v1.6.4
+        image: ghcr.io/layr-labs/eigenda-proxy:v1.6.5
         cmd:
           - --addr
           - 0.0.0.0
@@ -86,6 +86,8 @@ optimism_package:
 ethereum_package:
   participants:
     - el_type: geth
+      el_extra_params:
+        - --graphql # needed to query for batcher-inbox txs to test failover working correctly
       cl_type: teku
   network_params:
     preset: minimal

--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -155,10 +155,13 @@ eigenda-memstore-devnet-restart-batcher:
       --altda.da-server=http://da-server-op-kurtosis:3100 \
       --altda.da-service \
       --altda.max-concurrent-da-requests=1 \
-      --max-channel-duration=25 \
+      --max-channel-duration=2 \
       --target-num-frames=1 \
       --max-l1-tx-size-bytes=1000 \
       --batch-type=1
+[group('eigenda')]
+eigenda-memstore-devnet-test:
+    go test ./tests/eigenda/...
 
 # Simple devnet
 simple-devnet: (devnet "simple.yaml")

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -164,7 +164,7 @@ func (h *harness) requireBatcherTxsToBeFromLayer(t *testing.T, fromBlockNum, toB
 		if batcherTx.daLayer != expectedLayer {
 			wrongCommitmentsToDiscard++
 		}
-		// as soon as we see a commitmentment from expectedLayer, or 3 from the other layer, we stop discarding.
+		// as soon as we see a commitment from expectedLayer, or 3 from the other layer, we stop discarding.
 		if wrongCommitmentsToDiscard > 2 || batcherTx.daLayer == expectedLayer {
 			break
 		}

--- a/kurtosis-devnet/tests/eigenda/failover_test.go
+++ b/kurtosis-devnet/tests/eigenda/failover_test.go
@@ -1,0 +1,436 @@
+package eigenda_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Layr-Labs/eigenda-proxy/clients/memconfig_client"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/kurtosis-tech/kurtosis/api/golang/core/lib/enclaves"
+	"github.com/kurtosis-tech/kurtosis/api/golang/engine/lib/kurtosis_context"
+	"github.com/stretchr/testify/require"
+)
+
+// All tests are run in the context of the eigenda-memstore-devnet enclave.
+// We assume that this enclave is already running.
+const enclaveName = "eigenda-memstore-devnet"
+
+// TestFailover tests the failover behavior of the batcher, in response to the proxy returning 503 errors.
+// See https://github.com/Layr-Labs/eigenda-proxy?tab=readme-ov-file#failover-signals for proxy behavior.
+// The proxy's memstore's failover behavior is toggled on and off by this test via a REST api.
+// We then check that the batcher correctly interprets the 503 signals and starts submitting batches to EthDACalldata instead.
+// The test then toggles the failover back off and checks that the batcher starts submitting EigenDA batches again.
+// The batches inbox transactions are queried via geth's GraphQL API.
+//
+// Note: because this test relies on modifying the proxy's memstore config, it should be run in isolation.
+// That is, if we ever implement more kurtosis tests, they would currently need to be run sequentially.
+//
+// TODO: We will also need to test the failover behavior of the node, which currently doesn't finalize after failover (fixed in https://github.com/Layr-Labs/optimism/pull/23)
+func TestFailoverToEthDACalldata(t *testing.T) {
+	deadline, ok := t.Deadline()
+	if !ok {
+		deadline = time.Now().Add(1 * time.Minute)
+	}
+	ctxWithDeadline, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	harness := newHarness(t)
+	t.Cleanup(func() {
+		// switch proxy back to normal mode, in case test gets cancelled
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		err := harness.clients.proxyMemconfigClient.Failback(ctx)
+		if err != nil {
+			t.Logf("Error failing back... you might need to reset proxy to normal mode manually: %v", err)
+		}
+	})
+
+	// Number of blocks to queried for batcher txs, for each of the initial/failover/failback stages
+	// Test will look at batcher txs between blocks:
+	// - initial altda stage: [testStartL1BlockNum - l1BlocksQueriedForBatcherTxs, testStartL1BlockNum]
+	// - ethDACalldata stage: [afterFailoverFromBlockNum, afterFailoverFromBlockNum + l1BlocksQueriedForBatcherTxs]
+	// - altDA stage: [afterFailbackFromBlockNum, afterFailbackFromBlockNum + l1BlocksQueriedForBatcherTxs]
+	//
+	// After Failover/Failback, will wait for 10 L1 blocks to make sure failover/failback has happened.
+	// Assumption is that a cert is being posted every 2 blocks (hardcoded in batcher config)
+	// TODO: read max-channel-duration from batcher's config instead of assuming 2 blocks
+	l1BlocksQueriedForBatcherTxs := uint64(10)
+
+	// assume kurtosis is running and is at least at block numBlocksBetweenStages
+	require.GreaterOrEqual(t, harness.testStartL1BlockNum, l1BlocksQueriedForBatcherTxs, "Test started too early in the chain")
+	fromBlock := harness.testStartL1BlockNum - l1BlocksQueriedForBatcherTxs
+
+	// 1. Check that the original commitments are EigenDA
+	harness.requireBatcherTxsToBeFromLayer(t, fromBlock, fromBlock+l1BlocksQueriedForBatcherTxs, DALayerEigenDA)
+
+	// 2. Failover and check that the commitments are now EthDACalldata
+	t.Logf("Failover over... changing proxy's config to return 503 errors")
+	err := harness.clients.proxyMemconfigClient.Failover(ctxWithDeadline)
+	require.NoError(t, err)
+
+	afterFailoverFromBlockNum, err := harness.clients.gethL1Client.BlockNumber(ctxWithDeadline)
+	require.NoError(t, err)
+	afterFailoverToBlockNum := afterFailoverFromBlockNum + l1BlocksQueriedForBatcherTxs
+	_, err = geth.WaitForBlock(big.NewInt(int64(afterFailoverToBlockNum)), harness.clients.gethL1Client)
+	require.NoError(t, err)
+
+	harness.requireBatcherTxsToBeFromLayer(t, afterFailoverFromBlockNum, afterFailoverToBlockNum, DALayerEthCalldata)
+
+	// 3. Failback and check that the commitments are EigenDA again
+	t.Logf("Failing back... changing proxy's config to start processing PUT requests normally again")
+	err = harness.clients.proxyMemconfigClient.Failback(ctxWithDeadline)
+	require.NoError(t, err)
+
+	afterFailbackFromBlockNum, err := harness.clients.gethL1Client.BlockNumber(ctxWithDeadline)
+	require.NoError(t, err)
+	afterFailbackToBlockNum := afterFailbackFromBlockNum + l1BlocksQueriedForBatcherTxs
+	_, err = geth.WaitForBlock(big.NewInt(int64(afterFailbackToBlockNum)), harness.clients.gethL1Client)
+	require.NoError(t, err)
+
+	harness.requireBatcherTxsToBeFromLayer(t, afterFailbackFromBlockNum, afterFailbackToBlockNum, DALayerEigenDA)
+
+}
+
+// Test Harness, which contains all the state needed to run the tests.
+// harness also defines some higher-level "require" methods that are used in the tests.
+type harness struct {
+	endpoints           *EnclaveServicePublicEndpoints
+	clients             *EnclaveServiceClients
+	batchInboxAddr      common.Address
+	testStartL1BlockNum uint64
+}
+
+func newHarness(t *testing.T) *harness {
+	// We leave 20 seconds to build the entire testHarness.
+	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// Create a Kurtosis context
+	kurtosisCtx, err := kurtosis_context.NewKurtosisContextFromLocalEngine()
+	require.NoError(t, err)
+
+	// Get the eigenda-memstore-devnet enclave (assuming it's already running)
+	enclaveCtx, err := kurtosisCtx.GetEnclaveContext(ctxWithTimeout, enclaveName)
+	require.NoError(t, err, "Error getting enclave context: is enclave %v running?", enclaveName)
+
+	endpoints, err := getPublicEndpointsFromKurtosis(enclaveCtx)
+	require.NoError(t, err)
+	t.Logf("Endpoints: %+v", endpoints)
+
+	clients, err := getClientsFromEndpoints(endpoints)
+	require.NoError(t, err)
+
+	// Get the batch inbox address
+	var rollupConfigMap struct {
+		BatchInboxAddress string `json:"batch_inbox_address"`
+	}
+	err = clients.opNodeClient.CallContext(ctxWithTimeout, &rollupConfigMap, "optimism_rollupConfig")
+	require.NoError(t, err)
+
+	// Get the current L1 block number
+	testStartL1BlockNum, err := clients.gethL1Client.BlockNumber(ctxWithTimeout)
+	require.NoError(t, err)
+
+	return &harness{
+		endpoints:           endpoints,
+		clients:             clients,
+		batchInboxAddr:      common.HexToAddress(rollupConfigMap.BatchInboxAddress),
+		testStartL1BlockNum: testStartL1BlockNum,
+	}
+}
+
+// requireBatcherTxsToBeFromLayer checks that the batcher transactions since startingFromBlockNum are all from the expectedLayer.
+// It allows for up to 3 initial commitments to be of the wrong type, as the failover/failback might not have taken effect yet.
+// It requires that at least 2 commitments of the expected type are present after the failover/failback.
+func (h *harness) requireBatcherTxsToBeFromLayer(t *testing.T, fromBlockNum, toBlockNum uint64, expectedLayer DALayer) {
+	batcherTxs, err := fetchBatcherTxs(h.endpoints.GethL1Endpoint, h.batchInboxAddr.String(), fromBlockNum, toBlockNum)
+	require.NoError(t, err)
+	t.Logf("Fetched %d batcher transactions since block %d", len(batcherTxs), fromBlockNum)
+
+	// We allow first 3 commitments to be of the wrong DA layer, as the failover/failback might not have taken effect yet.
+	wrongCommitmentsToDiscard := 0
+	for _, batcherTx := range batcherTxs {
+		if batcherTx.daLayer != expectedLayer {
+			wrongCommitmentsToDiscard++
+		}
+		// as soon as we see a commitmentment from expectedLayer, or 3 from the other layer, we stop discarding.
+		if wrongCommitmentsToDiscard > 2 || batcherTx.daLayer == expectedLayer {
+			break
+		}
+	}
+	batcherTxs = batcherTxs[wrongCommitmentsToDiscard:]
+	t.Logf("Discarded %d commitments. %d left which should all be %v", wrongCommitmentsToDiscard, len(batcherTxs), expectedLayer)
+
+	// After potentially discarding up to 3 commitments, we expect all future commitments (at least 2) to be of the expectedLayer
+	require.GreaterOrEqual(t, len(batcherTxs), 2, "Expected at least 2 %v commitments after failover/failback", expectedLayer)
+	for _, batcherTx := range batcherTxs {
+		require.Equal(t, expectedLayer, batcherTx.daLayer,
+			"Invalid commitment in block %d: expected %v, received commitment %s", batcherTx.block, expectedLayer, batcherTx.commitment)
+	}
+}
+
+// See https://specs.optimism.io/experimental/alt-da.html#example-commitments
+// Batcher only supports failing over to calldata txs right now, so this test doesn't test 4844 failover.
+// Note that 4844 txs are completely different and don't use normal txs with a prefix in the calldata,
+// see https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/derive/blob_data_source.go#L134-L137
+const ethDACalldataCommitmentPrefix = "0x00"
+const eigenDACommitmentPrefix = "0x010100"
+
+type DALayer string
+
+const (
+	DALayerEthCalldata DALayer = "ethda-calldata"
+	DALayerEigenDA     DALayer = "eigenda"
+)
+
+type BatcherTx struct {
+	commitment string
+	daLayer    DALayer // commitment starts with respective prefix
+	block      uint64
+}
+
+// HexUint64 is a custom type that can unmarshal from a hex string
+type HexUint64 uint64
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (h *HexUint64) UnmarshalJSON(data []byte) error {
+	// Remove quotes from the JSON string
+	hexStr := string(data)
+	hexStr = strings.Trim(hexStr, "\"")
+
+	// Check if it's a hex string
+	if !strings.HasPrefix(hexStr, "0x") {
+		return fmt.Errorf("not a hex string: %s", hexStr)
+	}
+
+	// Parse the hex string (without the 0x prefix)
+	val, err := strconv.ParseUint(hexStr[2:], 16, 64)
+	if err != nil {
+		return err
+	}
+
+	*h = HexUint64(val)
+	return nil
+}
+
+// Fetches all the batch-inbox posted commitments from blockNum (inclusive) to current block.
+// We rely on geth's GraphQL API to fetch the batcher transactions.
+// We could possibly have reused op-node's L1Retriever, but the API felt very derivation-pipeline specific,
+// and there doesn't seem to be a way to reuse it easily for constructing a custom derivation-pipeline with a subset of stages
+// like what we need here. Could consider migrating in the future if we need more complex logic.
+func fetchBatcherTxs(gethL1Endpoint string, batchInbox string, fromBlockNum, toBlockNum uint64) ([]BatcherTx, error) {
+	// We use standard HTTP for GraphQL as it's not directly supported by the rpc package
+	// Visit gethL1Endpoint/graphql/ui to see the schema and test queries
+	query := fmt.Sprintf(`
+	{
+		"query": "query txInfo { blocks(from:%v, to:%v) { transactions { to { address } inputData block { number } } } }"
+	}`, fromBlockNum, toBlockNum)
+
+	// Make GraphQL request
+	req, err := http.NewRequest("POST", gethL1Endpoint+"/graphql", strings.NewReader(query))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Parse the response
+	type GraphQLResponse struct {
+		Data struct {
+			Blocks []struct {
+				Transactions []struct {
+					To struct {
+						Address string `json:"address"`
+					} `json:"to"`
+					InputData string `json:"inputData"`
+					Block     struct {
+						// we use HexUint64 to properly parse the hex strings returned
+						Number HexUint64 `json:"number"`
+					} `json:"block"`
+				} `json:"transactions"`
+			} `json:"blocks"`
+		} `json:"data"`
+	}
+	var graphQLResp GraphQLResponse
+	if err := json.NewDecoder(resp.Body).Decode(&graphQLResp); err != nil {
+		return nil, err
+	}
+	if len(graphQLResp.Data.Blocks) == 0 {
+		// Assume that this is a graphQL query error, that would have returned something like
+		// "errors": [
+		// 	{
+		// 	  "message": "syntax error: unexpected \"\", expecting Ident",
+		// 	}
+		// ]
+		// TODO: prob should just switch to a proper graphql client that can handle these properly
+		return nil, fmt.Errorf("no blocks returned in GraphQL response")
+	}
+
+	// Filter transactions to the batcher address
+	var batcherTxs []BatcherTx
+	for _, block := range graphQLResp.Data.Blocks {
+		for _, tx := range block.Transactions {
+			if strings.EqualFold(tx.To.Address, batchInbox) {
+				var daLayer DALayer
+				if strings.HasPrefix(tx.InputData, eigenDACommitmentPrefix) {
+					daLayer = DALayerEigenDA
+				} else if strings.HasPrefix(tx.InputData, ethDACalldataCommitmentPrefix) {
+					daLayer = DALayerEthCalldata
+				} else {
+					return nil, fmt.Errorf("unknown commitment prefix: %s", tx.InputData)
+				}
+				batcherTxs = append(batcherTxs, BatcherTx{
+					commitment: tx.InputData,
+					daLayer:    daLayer,
+					block:      uint64(tx.Block.Number),
+				})
+			}
+		}
+	}
+
+	return batcherTxs, nil
+}
+
+// Localhost endpoints for the different services in the enclave
+// that we need to interact with. We store the public localhost endpoints instead
+// of the private enclave endpoints because we need to interact with the services
+// using external shell commands like `cast rpc ...` and `cast geth ...`.
+// The public endpoints are the ones that are exposed to the host machine.
+type EnclaveServicePublicEndpoints struct {
+	OpNodeEndpoint       string `kurtosis:"op-cl-1-op-node-op-geth-op-kurtosis,http"`
+	GethL1Endpoint       string `kurtosis:"el-1-geth-teku,rpc"`
+	EigendaProxyEndpoint string `kurtosis:"da-server-op-kurtosis,http"`
+	// Adding new endpoints is as simple as adding a new field with a kurtosis tag
+	// NewServiceEndpoint   string `kurtosis:"new-service-name,port-name"`
+}
+
+// Constructor for EnclaveServiceEndpoints struct, which assumes a running kurtosis enclave
+// and queries the needed services for their public (localhost) ports, and constructs
+// the struct with the endpoints.
+//
+// This function uses reflection to parse the `kurtosis` tags in the struct fields to get the service name and port name.
+// See the comments in the EnclaveServicePublicEndpoints struct for more details on adding a new endpoint.
+func getPublicEndpointsFromKurtosis(enclaveCtx *enclaves.EnclaveContext) (*EnclaveServicePublicEndpoints, error) {
+	endpoints := &EnclaveServicePublicEndpoints{}
+
+	// Get the type of the struct to iterate over fields
+	t := reflect.TypeOf(endpoints).Elem()
+	v := reflect.ValueOf(endpoints).Elem()
+
+	// Iterate over all fields in the struct
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		// Get the kurtosis tag
+		tag := field.Tag.Get("kurtosis")
+		if tag == "" {
+			return nil, fmt.Errorf("field %s doesn't have a kurtosis tag", field.Name)
+		}
+
+		// Parse the tag to get service name and port name
+		parts := strings.Split(tag, ",")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid kurtosis tag format for field %s: %s", field.Name, tag)
+		}
+
+		serviceName := parts[0]
+		portName := parts[1]
+
+		// Get the service context
+		serviceCtx, err := enclaveCtx.GetServiceContext(serviceName)
+		if err != nil {
+			return nil, fmt.Errorf("GetServiceContext for %s: %w", serviceName, err)
+		}
+
+		// Get the port
+		port, ok := serviceCtx.GetPublicPorts()[portName]
+		if !ok {
+			return nil, fmt.Errorf("service %s doesn't expose %s port", serviceName, portName)
+		}
+
+		// Set the endpoint URL in the struct field
+		endpoint := fmt.Sprintf("http://localhost:%d", port.GetNumber())
+		v.Field(i).SetString(endpoint)
+	}
+
+	return endpoints, nil
+}
+
+type EnclaveServiceClients struct {
+	opNodeClient         *rpc.Client
+	gethL1Client         *ethclient.Client
+	proxyMemconfigClient *ProxyMemconfigClient
+}
+
+func getClientsFromEndpoints(endpoints *EnclaveServicePublicEndpoints) (*EnclaveServiceClients, error) {
+	opNodeClient, err := rpc.Dial(endpoints.OpNodeEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("rpc.Dial: %w", err)
+	}
+
+	gethL1Client, err := ethclient.Dial(endpoints.GethL1Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("ethclient.Dial: %w", err)
+	}
+
+	proxyMemconfigClient := &ProxyMemconfigClient{
+		Client: memconfig_client.New(&memconfig_client.Config{URL: endpoints.EigendaProxyEndpoint}),
+	}
+
+	return &EnclaveServiceClients{
+		opNodeClient:         opNodeClient,
+		gethL1Client:         gethL1Client,
+		proxyMemconfigClient: proxyMemconfigClient,
+	}, nil
+}
+
+// ProxyMemconfigClient is a wrapper around the memconfig client that adds a Failover method
+// TODO: we should upstream this to eigenda-proxy repo
+type ProxyMemconfigClient struct {
+	*memconfig_client.Client
+}
+
+// Update the proxy's memstore config to start returning 503 errors
+// Note: we have to GetConfig, update it and then UpdateConfig because the client doesn't implement a "patch" method,
+// even though the API does support it.
+func (c *ProxyMemconfigClient) Failover(ctx context.Context) error {
+	memConfig, err := c.GetConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("GetConfig: %w", err)
+	}
+	memConfig.PutReturnsFailoverError = true
+	_, err = c.UpdateConfig(ctx, memConfig)
+	if err != nil {
+		return fmt.Errorf("UpdateConfig: %w", err)
+	}
+	return nil
+}
+func (c *ProxyMemconfigClient) Failback(ctx context.Context) error {
+	memConfig, err := c.GetConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("GetConfig: %w", err)
+	}
+	memConfig.PutReturnsFailoverError = false
+	_, err = c.UpdateConfig(ctx, memConfig)
+	if err != nil {
+		return fmt.Errorf("UpdateConfig: %w", err)
+	}
+	return nil
+}

--- a/op-alt-da/damock.go
+++ b/op-alt-da/damock.go
@@ -137,6 +137,7 @@ func (s *FakeDAServer) HandlePut(w http.ResponseWriter, r *http.Request) {
 	if s.failoverCount > 0 {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		s.failoverCount--
+		return
 	}
 	s.DAServer.HandlePut(w, r)
 }

--- a/op-alt-da/damock.go
+++ b/op-alt-da/damock.go
@@ -164,7 +164,7 @@ func (s *FakeDAServer) SetGetRequestLatency(latency time.Duration) {
 
 // SetResponseStatusForNRequests sets the next n Put requests to return 503 status code.
 func (s *FakeDAServer) SetPutFailoverForNRequests(n uint64) {
-	s.failoverCount = uint64(n)
+	s.failoverCount = n
 }
 
 type MemStore struct {

--- a/op-batcher/batcher/channel.go
+++ b/op-batcher/batcher/channel.go
@@ -65,6 +65,7 @@ func (c *channel) TxFailed(id string, failoverToEthDA bool) {
 		// and is only used while the altDA is down, so we can afford to be inefficient here.
 		// TODO: figure out how to switch to blobs/auto instead. Might need to make
 		// batcherService.initChannelConfig function stateless so that we can reuse it.
+		c.log.Info("Failing over to calldata txs", "id", c.ID())
 		c.cfg.DaType = DaTypeCalldata
 	}
 	c.metr.RecordBatchTxFailed()

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -92,12 +92,13 @@ func (s *channelManager) pendingBlocks() int {
 }
 
 // TxFailed records a transaction as failed. It will attempt to resubmit the data
-// in the failed transaction.
-func (s *channelManager) TxFailed(_id txID) {
+// in the failed transaction. failoverToEthDA should be set to true when using altDA
+// and altDA is down. This will switch the channel to submit frames to ethDA instead.
+func (s *channelManager) TxFailed(_id txID, failoverToEthDA bool) {
 	id := _id.String()
 	if channel, ok := s.txChannels[id]; ok {
 		delete(s.txChannels, id)
-		channel.TxFailed(id)
+		channel.TxFailed(id, failoverToEthDA)
 	} else {
 		s.log.Warn("transaction from unknown channel marked as failed", "id", id)
 	}

--- a/op-batcher/batcher/channel_manager.go
+++ b/op-batcher/batcher/channel_manager.go
@@ -318,7 +318,7 @@ func (s *channelManager) ensureChannelWithSpace(l1Head eth.BlockID) error {
 		"compression_algo", cfg.CompressorConfig.CompressionAlgo,
 		"target_num_frames", cfg.TargetNumFrames,
 		"max_frame_size", cfg.MaxFrameSize,
-		"da_type", cfg.DaType,
+		"da_type", cfg.DaType.String(),
 	)
 	s.metr.RecordChannelOpened(pc.ID(), s.pendingBlocks())
 

--- a/op-batcher/batcher/channel_manager_test.go
+++ b/op-batcher/batcher/channel_manager_test.go
@@ -211,7 +211,7 @@ func ChannelManager_TxResend(t *testing.T, batchType uint) {
 	require.ErrorIs(err, io.EOF)
 
 	// requeue frame
-	m.TxFailed(txdata0.ID())
+	m.TxFailed(txdata0.ID(), false)
 
 	txdata1, err := m.TxData(eth.BlockID{}, false)
 	require.NoError(err)

--- a/op-batcher/batcher/channel_test.go
+++ b/op-batcher/batcher/channel_test.go
@@ -305,13 +305,13 @@ func TestChannelTxFailed(t *testing.T) {
 
 	// Trying to mark an unknown pending transaction as failed
 	// shouldn't modify state
-	m.TxFailed(zeroFrameTxID(0))
+	m.TxFailed(zeroFrameTxID(0), false)
 	require.Equal(t, 0, m.currentChannel.PendingFrames())
 	require.Equal(t, expectedTxData, m.currentChannel.pendingTransactions[expectedChannelID.String()])
 
 	// Now we still have a pending transaction
 	// Let's mark it as failed
-	m.TxFailed(expectedChannelID)
+	m.TxFailed(expectedChannelID, false)
 	require.Empty(t, m.currentChannel.pendingTransactions)
 	// There should be a frame in the pending channel now
 	require.Equal(t, 1, m.currentChannel.PendingFrames())

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -903,7 +903,7 @@ func (l *BatchSubmitter) recordFailedDARequest(id txID, err error) {
 	defer l.channelMgrMutex.Unlock()
 	failover := errors.Is(err, altda.ErrAltDADown)
 	if err != nil {
-		l.Log.Warn("DA request failed", append([]interface{}{"failoverToEthDA", failover}, logFields(id, err))...)
+		l.Log.Warn("DA request failed", append([]interface{}{"failoverToEthDA", failover}, logFields(id, err)...)...)
 	}
 	l.channelMgr.TxFailed(id, failover)
 }

--- a/op-batcher/batcher/driver.go
+++ b/op-batcher/batcher/driver.go
@@ -901,17 +901,18 @@ func (l *BatchSubmitter) handleReceipt(r txmgr.TxReceipt[txRef]) {
 func (l *BatchSubmitter) recordFailedDARequest(id txID, err error) {
 	l.channelMgrMutex.Lock()
 	defer l.channelMgrMutex.Unlock()
+	failover := errors.Is(err, altda.ErrAltDADown)
 	if err != nil {
-		l.Log.Warn("DA request failed", logFields(id, err)...)
+		l.Log.Warn("DA request failed", append([]interface{}{"failoverToEthDA", failover}, logFields(id, err))...)
 	}
-	l.channelMgr.TxFailed(id)
+	l.channelMgr.TxFailed(id, failover)
 }
 
 func (l *BatchSubmitter) recordFailedTx(id txID, err error) {
 	l.channelMgrMutex.Lock()
 	defer l.channelMgrMutex.Unlock()
 	l.Log.Warn("Transaction failed to send", logFields(id, err)...)
-	l.channelMgr.TxFailed(id)
+	l.channelMgr.TxFailed(id, false)
 }
 
 func (l *BatchSubmitter) recordConfirmedTx(id txID, receipt *types.Receipt) {

--- a/op-batcher/batcher/tx_data.go
+++ b/op-batcher/batcher/tx_data.go
@@ -21,6 +21,19 @@ const (
 	DaTypeAltDA
 )
 
+func (d DaType) String() string {
+	switch d {
+	case DaTypeCalldata:
+		return "calldata"
+	case DaTypeBlob:
+		return "blob"
+	case DaTypeAltDA:
+		return "alt_da"
+	default:
+		return fmt.Sprintf("unknown_da_type_%d", d)
+	}
+}
+
 // txData represents the data for a single transaction.
 //
 // Note: The batcher currently sends exactly one frame per transaction. This

--- a/op-e2e/e2eutils/geth/wait.go
+++ b/op-e2e/e2eutils/geth/wait.go
@@ -88,7 +88,9 @@ func WaitForTransaction(hash common.Hash, client *ethclient.Client, timeout time
 }
 
 // WaitForBlockWithTxFromSender waits for a block with a transaction from a specific sender address.
-// It starts from the current block and checks the next nBlocks blocks.
+// It starts from the current block and checks up to the next nBlocks blocks.
+// As soon as it finds a block that contains a tx from sender, it returns that block.
+// If no such block is found in the next nBlocks blocks, it returns an error.
 func WaitForBlockWithTxFromSender(sender common.Address, client *ethclient.Client, nBlocks uint64) (*types.Block, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/op-e2e/e2eutils/transactions/count.go
+++ b/op-e2e/e2eutils/transactions/count.go
@@ -5,7 +5,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-func TransactionsBySender(block *types.Block, sender common.Address) (int64, error) {
+// TransactionsBySenderCount returns the number of transactions in the block that were sent by the given sender.
+func TransactionsBySenderCount(block *types.Block, sender common.Address) (int64, error) {
 	txCount := int64(0)
 	for _, tx := range block.Transactions() {
 		signer := types.NewCancunSigner(tx.ChainId())
@@ -18,4 +19,19 @@ func TransactionsBySender(block *types.Block, sender common.Address) (int64, err
 		}
 	}
 	return txCount, nil
+}
+
+func TransactionsBySender(block *types.Block, sender common.Address) ([]*types.Transaction, error) {
+	txs := make([]*types.Transaction, 0)
+	for _, tx := range block.Transactions() {
+		signer := types.NewCancunSigner(tx.ChainId())
+		txSender, err := types.Sender(signer, tx)
+		if err != nil {
+			return nil, err
+		}
+		if txSender == sender {
+			txs = append(txs, tx)
+		}
+	}
+	return txs, nil
 }

--- a/op-e2e/e2eutils/transactions/count.go
+++ b/op-e2e/e2eutils/transactions/count.go
@@ -21,6 +21,8 @@ func TransactionsBySenderCount(block *types.Block, sender common.Address) (int64
 	return txCount, nil
 }
 
+// TransactionsBySender returns the transactions (possibly none) in the block that were sent by the given sender.
+// It returns an error if any of the transactions in the block have an invalid signature.
 func TransactionsBySender(block *types.Block, sender common.Address) ([]*types.Transaction, error) {
 	txs := make([]*types.Transaction, 0)
 	for _, tx := range block.Transactions() {

--- a/op-e2e/system/altda/concurrent_test.go
+++ b/op-e2e/system/altda/concurrent_test.go
@@ -73,7 +73,7 @@ func TestBatcherConcurrentAltDARequests(t *testing.T) {
 		require.NoError(t, err, "Waiting for l1 blocks")
 		// there are possibly other services (proposer/challenger) in the background sending txs
 		// so we only count the batcher txs
-		batcherTxCount, err := transactions.TransactionsBySender(block, cfg.DeployConfig.BatchSenderAddress)
+		batcherTxCount, err := transactions.TransactionsBySenderCount(block, cfg.DeployConfig.BatchSenderAddress)
 		require.NoError(t, err)
 		if batcherTxCount > 1 {
 			return

--- a/op-e2e/system/altda/failover_test.go
+++ b/op-e2e/system/altda/failover_test.go
@@ -57,7 +57,7 @@ func TestBatcher_FailoverToEthDA_FallbackToAltDA(t *testing.T) {
 	countEthDACommitment := uint64(0)
 
 	// There is some nondeterministic timing behavior that affects whether the batcher has already
-	// posted batches before seeing the abvoe SetPutFailoverForNRequests behavior change.
+	// posted batches before seeing the above SetPutFailoverForNRequests behavior change.
 	// Most likely, sequence of blocks will be: altDA, ethDA, ethDA, altDA, altDA, altDA.
 	// 2 ethDA are expected (and checked for) because nChannelsFailover=2, so da-server will return 503 for 2 requests only,
 	// and the batcher always tries altda first for a new channel, and failsover to ethDA only if altda returns 503.

--- a/op-e2e/system/altda/failover_test.go
+++ b/op-e2e/system/altda/failover_test.go
@@ -1,0 +1,84 @@
+package altda
+
+import (
+	"math/big"
+	"testing"
+
+	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive/params"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-batcher/flags"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/geth"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/transactions"
+	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBatcher_FailoverToEthDA_FallbackToAltDA tests that the batcher will failover to ethDA
+// if the da-server returns 503. It also tests that the batcher successfully returns to normal
+// behavior of posting batches to altda once it becomes available again
+// (i.e. the da-server doesn't return 503 anymore).
+func TestBatcher_FailoverToEthDA_FallbackToAltDA(t *testing.T) {
+	op_e2e.InitParallel(t)
+
+	nChannelsFailover := uint64(2)
+
+	cfg := e2esys.DefaultSystemConfig(t, e2esys.WithLogLevel(log.LevelCrit))
+	cfg.DeployConfig.UseAltDA = true
+	cfg.DeployConfig.DACommitmentType = "GenericCommitment"
+	cfg.DeployConfig.DAChallengeWindow = 16
+	cfg.DeployConfig.DAResolveWindow = 16
+	cfg.DeployConfig.DABondSize = 1000000
+	cfg.DeployConfig.DAResolverRefundPercentage = 0
+	// With these settings, the batcher will post a single commitment per L1 block,
+	// so it's easy to trigger failover and observe the commitment changing on the next L1 block.
+	cfg.BatcherMaxPendingTransactions = 1 // no limit on parallel txs
+	cfg.BatcherMaxConcurrentDARequest = 1
+	cfg.BatcherBatchType = 0
+	// We make channels as small as possible, such that they contain a single commitment.
+	// This is because failover to ethDA happens on a per-channel basis (each new channel is sent to altDA first).
+	// Hence, we can quickly observe the failover (to ethda) and fallback (to altda) behavior.
+	// cfg.BatcherMaxL1TxSizeBytes = 1200
+	// currently altda commitments can only be sent as calldata
+	cfg.DataAvailabilityType = flags.CalldataType
+
+	sys, err := cfg.Start(t)
+	require.NoError(t, err, "Error starting up system")
+	defer sys.Close()
+	l1Client := sys.NodeClient("l1")
+
+	startBlockL1, err := geth.WaitForBlockWithTxFromSender(cfg.DeployConfig.BatchSenderAddress, l1Client, 10)
+	require.NoError(t, err)
+
+	// Simulate altda server returning 503
+	sys.FakeAltDAServer.SetPutFailoverForNRequests(nChannelsFailover)
+
+	countEthDACommitment := uint64(0)
+
+	// There is some nondeterministic timing behavior that affects whether the batcher has already
+	// posted batches before seeing the abvoe SetPutFailoverForNRequests behavior change.
+	// Most likely, sequence of blocks will be: altDA, ethDA, ethDA, altDA, altDA, altDA.
+	// 2 ethDA are expected (and checked for) because nChannelsFailover=2, so da-server will return 503 for 2 requests only,
+	// and the batcher always tries altda first for a new channel, and failsover to ethDA only if altda returns 503.
+	for blockNumL1 := startBlockL1.NumberU64(); blockNumL1 < startBlockL1.NumberU64()+6; blockNumL1++ {
+		blockL1, err := geth.WaitForBlock(big.NewInt(0).SetUint64(blockNumL1), l1Client)
+		require.NoError(t, err)
+		batcherTxs, err := transactions.TransactionsBySender(blockL1, cfg.DeployConfig.BatchSenderAddress)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(batcherTxs)) // sanity check: ensure BatcherMaxPendingTransactions=1 is working
+		batcherTx := batcherTxs[0]
+		if batcherTx.Data()[0] == 1 {
+			t.Log("blockL1", blockNumL1, "batcherTxType", "altda")
+		} else if batcherTx.Data()[0] == 0 {
+			t.Log("blockL1", blockNumL1, "batcherTxType", "ethda")
+		} else {
+			t.Fatalf("unexpected batcherTxType: %v", batcherTx.Data()[0])
+		}
+		if batcherTx.Data()[0] == byte(params.DerivationVersion0) {
+			countEthDACommitment++
+		}
+	}
+	require.Equal(t, nChannelsFailover, countEthDACommitment, "Expected %v ethDA commitments, got %v", nChannelsFailover, countEthDACommitment)
+
+}

--- a/op-e2e/system/altda/failover_test.go
+++ b/op-e2e/system/altda/failover_test.go
@@ -33,7 +33,7 @@ func TestBatcher_FailoverToEthDA_FallbackToAltDA(t *testing.T) {
 	cfg.DeployConfig.DAResolverRefundPercentage = 0
 	// With these settings, the batcher will post a single commitment per L1 block,
 	// so it's easy to trigger failover and observe the commitment changing on the next L1 block.
-	cfg.BatcherMaxPendingTransactions = 1 // no limit on parallel txs
+	cfg.BatcherMaxPendingTransactions = 1
 	cfg.BatcherMaxConcurrentDARequest = 1
 	cfg.BatcherBatchType = 0
 	// We make channels as small as possible, such that they contain a single commitment.

--- a/op-e2e/system/altda/failover_test.go
+++ b/op-e2e/system/altda/failover_test.go
@@ -66,15 +66,13 @@ func TestBatcher_FailoverToEthDA_FallbackToAltDA(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(batcherTxs)) // sanity check: ensure BatcherMaxPendingTransactions=1 is working
 		batcherTx := batcherTxs[0]
-		if batcherTx.Data()[0] == 1 {
-			t.Log("blockL1", blockNumL1, "batcherTxType", "altda")
-		} else if batcherTx.Data()[0] == 0 {
-			t.Log("blockL1", blockNumL1, "batcherTxType", "ethda")
-		} else {
-			t.Fatalf("unexpected batcherTxType: %v", batcherTx.Data()[0])
-		}
 		if batcherTx.Data()[0] == byte(params.DerivationVersion0) {
 			countEthDACommitment++
+			t.Log("blockL1", blockNumL1, "batcherTxType", "ethda")
+		} else if batcherTx.Data()[0] == byte(params.DerivationVersion1) {
+			t.Log("blockL1", blockNumL1, "batcherTxType", "altda")
+		} else {
+			t.Fatalf("unexpected batcherTxType: %v", batcherTx.Data()[0])
 		}
 	}
 	require.Equal(t, nChannelsFailover, countEthDACommitment, "Expected %v ethDA commitments, got %v", nChannelsFailover, countEthDACommitment)

--- a/op-e2e/system/altda/failover_test.go
+++ b/op-e2e/system/altda/failover_test.go
@@ -31,15 +31,13 @@ func TestBatcher_FailoverToEthDA_FallbackToAltDA(t *testing.T) {
 	cfg.DeployConfig.DAResolveWindow = 16
 	cfg.DeployConfig.DABondSize = 1000000
 	cfg.DeployConfig.DAResolverRefundPercentage = 0
-	// With these settings, the batcher will post a single commitment per L1 block,
-	// so it's easy to trigger failover and observe the commitment changing on the next L1 block.
+	// Default cfg.BatcherMaxChannelDuration is 1, which means at least one channel is sent per L1 block.
+	// Furthermore, by setting cfg.BatcherMaxPendingTransactions = 1,
+	// we make sure the batcher posts a single commitment per L1 block.
+	// This way it's easy to trigger failover and observe the commitment changing on the next L1 block.
 	cfg.BatcherMaxPendingTransactions = 1
 	cfg.BatcherMaxConcurrentDARequest = 1
 	cfg.BatcherBatchType = 0
-	// We make channels as small as possible, such that they contain a single commitment.
-	// This is because failover to ethDA happens on a per-channel basis (each new channel is sent to altDA first).
-	// Hence, we can quickly observe the failover (to ethda) and fallback (to altda) behavior.
-	// cfg.BatcherMaxL1TxSizeBytes = 1200
 	// currently altda commitments can only be sent as calldata
 	cfg.DataAvailabilityType = flags.CalldataType
 

--- a/op-e2e/system/da/multi_test.go
+++ b/op-e2e/system/da/multi_test.go
@@ -52,7 +52,7 @@ func TestBatcherMultiTx(t *testing.T) {
 			block, err := l1Client.BlockByNumber(ctx, big.NewInt(int64(i)))
 			require.NoError(t, err)
 
-			batcherTxCount, err := transactions.TransactionsBySender(block, cfg.DeployConfig.BatchSenderAddress)
+			batcherTxCount, err := transactions.TransactionsBySenderCount(block, cfg.DeployConfig.BatchSenderAddress)
 			require.NoError(t, err)
 			totalBatcherTxsCount += batcherTxCount
 

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"net"
 	"os"
@@ -87,6 +88,7 @@ var (
 
 type SystemConfigOpts struct {
 	AllocType config.AllocType
+	LogLevel  slog.Level
 }
 
 type SystemConfigOpt func(s *SystemConfigOpts)
@@ -97,9 +99,16 @@ func WithAllocType(allocType config.AllocType) SystemConfigOpt {
 	}
 }
 
+func WithLogLevel(level slog.Level) SystemConfigOpt {
+	return func(s *SystemConfigOpts) {
+		s.LogLevel = level
+	}
+}
+
 func DefaultSystemConfig(t testing.TB, opts ...SystemConfigOpt) SystemConfig {
 	sco := &SystemConfigOpts{
 		AllocType: config.DefaultAllocType,
+		LogLevel:  slog.LevelInfo,
 	}
 	for _, opt := range opts {
 		opt(sco)
@@ -110,7 +119,7 @@ func DefaultSystemConfig(t testing.TB, opts ...SystemConfigOpt) SystemConfig {
 	deployConfig := config.DeployConfig(sco.AllocType)
 	deployConfig.L1GenesisBlockTimestamp = hexutil.Uint64(time.Now().Unix())
 	e2eutils.ApplyDeployConfigForks(deployConfig)
-	require.NoError(t, deployConfig.Check(testlog.Logger(t, log.LevelInfo)),
+	require.NoError(t, deployConfig.Check(testlog.Logger(t, sco.LogLevel).New("role", "config-check")),
 		"Deploy config is invalid, do you need to run make devnet-allocs?")
 	l1Deployments := config.L1Deployments(sco.AllocType)
 	require.NoError(t, l1Deployments.Check(deployConfig))
@@ -172,11 +181,12 @@ func DefaultSystemConfig(t testing.TB, opts ...SystemConfigOpt) SystemConfig {
 			},
 		},
 		Loggers: map[string]log.Logger{
-			RoleVerif:   testlog.Logger(t, log.LevelInfo).New("role", RoleVerif),
-			RoleSeq:     testlog.Logger(t, log.LevelInfo).New("role", RoleSeq),
-			"batcher":   testlog.Logger(t, log.LevelInfo).New("role", "batcher"),
-			"proposer":  testlog.Logger(t, log.LevelInfo).New("role", "proposer"),
-			"da-server": testlog.Logger(t, log.LevelInfo).New("role", "da-server"),
+			RoleVerif:      testlog.Logger(t, sco.LogLevel).New("role", RoleVerif),
+			RoleSeq:        testlog.Logger(t, sco.LogLevel).New("role", RoleSeq),
+			"batcher":      testlog.Logger(t, sco.LogLevel).New("role", "batcher"),
+			"proposer":     testlog.Logger(t, sco.LogLevel).New("role", "proposer"),
+			"da-server":    testlog.Logger(t, sco.LogLevel).New("role", "da-server"),
+			"config-check": testlog.Logger(t, sco.LogLevel).New("role", "config-check"),
 		},
 		GethOptions:                   map[string][]geth.GethOption{},
 		P2PTopology:                   nil, // no P2P connectivity by default
@@ -275,12 +285,10 @@ type SystemConfig struct {
 	// L1FinalizedDistance is the distance from the L1 head that L1 blocks will be artificially finalized on.
 	L1FinalizedDistance uint64
 
-	Premine        map[common.Address]*big.Int
-	Nodes          map[string]*rollupNode.Config // Per node config. Don't use populate rollup.Config
-	Loggers        map[string]log.Logger
-	GethOptions    map[string][]geth.GethOption
-	ProposerLogger log.Logger
-	BatcherLogger  log.Logger
+	Premine     map[common.Address]*big.Int
+	Nodes       map[string]*rollupNode.Config // Per node config. Don't use populate rollup.Config
+	Loggers     map[string]log.Logger
+	GethOptions map[string][]geth.GethOption
 
 	ExternalL2Shim string
 
@@ -551,7 +559,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 		c = sys.TimeTravelClock
 	}
 
-	if err := cfg.DeployConfig.Check(testlog.Logger(t, log.LevelInfo)); err != nil {
+	if err := cfg.DeployConfig.Check(cfg.Loggers["config-check"]); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Closes DAINT-103

This PR contains 2 commits:
1. failover test (failing)
2. failover logic (fix to make test pass)

Right now failover is done to calldata txs because that was trivial whereas failing over to blobs or their auto mode that switches between blobs and calldata would need a nontrivial refactor and some thinking. Not sure its worth putting effort into this atm given that the whole point of failover is that it should happen very rarely and also not last very long, but let me know if you guys think otherwise.

### Note to reviewers
This PR contains the same logic as https://github.com/Layr-Labs/optimism/pull/24 which was already reviewed. I closed that one by mistake when merging (and deleting) the multiframe branch. Github not letting me reopen it or change its target branch... so opening this one instead.