### PR TITLE
ci: attempt to fix ci

### DIFF
--- a/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
+++ b/kurtosis-devnet/optimism-package-trampoline/kurtosis.yml
@@ -3,6 +3,6 @@ description: |-
   A trampoline package for optimism-package. This one is reproducible, due to the replace directives below.
 replace:
   github.com/ethpandaops/optimism-package: github.com/ethpandaops/optimism-package@1cf76907eaa437ee9fcf902167714fece027962a
-  github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@4.5.0
+  github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@83830d44823767af65eda7dfe6b26c87c536c4cf
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@f5ce159aec728898e3deb827f6b921f8ecfc527f
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@2d363be1bc42524f6b0575cac0bbc0fd194ae173


### PR DESCRIPTION
Closes DAINT-424

No idea what is causing the CI to fail today.
It was passing yesterday in https://github.com/Layr-Labs/optimism/pull/42, but after merging this morning CI keeps failing on this stupid bash python wheel bug.

EDIT: turns out it was a regression in the latest python3.11-alpine docker image that kurtosis and ethereum-package were using by default. See https://github.com/ethpandaops/ethereum-package/issues/956