### PR TITLE
feat(altda-client): punctuality check via passing l1_inclusion_block_num to da-server

### DIFF
--- a/op-alt-da/daclient.go
+++ b/op-alt-da/daclient.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 // ErrNotFound is returned when the server could not find the input.
@@ -33,6 +35,8 @@ type DAClient struct {
 	putTimeout time.Duration
 }
 
+var _ DAStorage = (*DAClient)(nil)
+
 func NewDAClient(url string, verify bool, pc bool) *DAClient {
 	return &DAClient{
 		url:        url,
@@ -42,8 +46,10 @@ func NewDAClient(url string, verify bool, pc bool) *DAClient {
 }
 
 // GetInput returns the input data for the given encoded commitment bytes.
-func (c *DAClient) GetInput(ctx context.Context, comm CommitmentData) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/get/0x%x", c.url, comm.Encode()), nil)
+// The l1InclusionBlock at which the commitment was included in the batcher-inbox is submitted to the DA server.
+// It is used to discard old commitments whose blobs have a risk of not being available anymore.
+func (c *DAClient) GetInput(ctx context.Context, comm CommitmentData, l1InclusionBlock eth.L1BlockRef) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/get/0x%x?l1_inclusion_block_number=%d", c.url, comm.Encode(), l1InclusionBlock.Number), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}

--- a/op-alt-da/daclient.go
+++ b/op-alt-da/daclient.go
@@ -8,8 +8,6 @@ import (
 	"io"
 	"net/http"
 	"time"
-
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 // ErrNotFound is returned when the server could not find the input.
@@ -58,10 +56,12 @@ func NewDAClient(url string, verify bool, pc bool) *DAClient {
 }
 
 // GetInput returns the input data for the given encoded commitment bytes.
-// The l1InclusionBlock at which the commitment was included in the batcher-inbox is submitted to the DA server.
+// The l1InclusionBlock at which the commitment was included in the batcher-inbox is submitted
+// to the DA server as a query parameter.
 // It is used to discard old commitments whose blobs have a risk of not being available anymore.
-func (c *DAClient) GetInput(ctx context.Context, comm CommitmentData, l1InclusionBlock eth.L1BlockRef) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/get/0x%x?l1_inclusion_block_number=%d", c.url, comm.Encode(), l1InclusionBlock.Number), nil)
+// It is optional, and passing a 0 value will tell the DA server to skip the check.
+func (c *DAClient) GetInput(ctx context.Context, comm CommitmentData, l1InclusionBlockNumber uint64) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/get/0x%x?l1_inclusion_block_number=%d", c.url, comm.Encode(), l1InclusionBlockNumber), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}

--- a/op-alt-da/daclient.go
+++ b/op-alt-da/daclient.go
@@ -23,6 +23,18 @@ var ErrInvalidInput = errors.New("invalid input")
 // See https://github.com/ethereum-optimism/specs/issues/434
 var ErrAltDADown = errors.New("alt DA is down: failover to eth DA")
 
+// InvalidCommitmentError is returned when the altda commitment is invalid
+// and should be dropped from the derivation pipeline.
+// Validity conditions for altda commitments are altda-layer-specific, so are done in da-servers.
+// They should be returned as 418 (I'M A TEAPOT) errors, with a body containing the reason.
+type InvalidCommitmentError struct {
+	Reason string
+}
+
+func (e InvalidCommitmentError) Error() string {
+	return fmt.Sprintf("Invalid AltDA Commitment: %v", e.Reason)
+}
+
 // DAClient is an HTTP client to communicate with a DA storage service.
 // It creates commitments and retrieves input data + verifies if needed.
 type DAClient struct {
@@ -60,6 +72,14 @@ func (c *DAClient) GetInput(ctx context.Context, comm CommitmentData, l1Inclusio
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
+	}
+	if resp.StatusCode == http.StatusTeapot {
+		defer resp.Body.Close()
+		var invalidCommitmentReason [250]byte
+		// We discard the error as it only contains the reason for invalidity.
+		// We might end up with a partial reason, but the commitment should still be skipped.
+		_, _ = io.ReadFull(resp.Body, invalidCommitmentReason[:])
+		return nil, InvalidCommitmentError{Reason: string(invalidCommitmentReason[:])}
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to get preimage: %v", resp.StatusCode)

--- a/op-alt-da/daclient.go
+++ b/op-alt-da/daclient.go
@@ -75,11 +75,12 @@ func (c *DAClient) GetInput(ctx context.Context, comm CommitmentData, l1Inclusio
 	}
 	if resp.StatusCode == http.StatusTeapot {
 		defer resp.Body.Close()
-		var invalidCommitmentReason [250]byte
+		// Limit the body to 1000 bytes to prevent being DDoSed with a large error message.
+		bytesLimitedBody := http.MaxBytesReader(nil, resp.Body, 1000)
 		// We discard the error as it only contains the reason for invalidity.
-		// We might end up with a partial reason, but the commitment should still be skipped.
-		_, _ = io.ReadFull(resp.Body, invalidCommitmentReason[:])
-		return nil, InvalidCommitmentError{Reason: string(invalidCommitmentReason[:])}
+		// We might read a partial or missing reason, but the commitment should still be skipped.
+		invalidCommitmentReason, _ := io.ReadAll(bytesLimitedBody)
+		return nil, InvalidCommitmentError{Reason: string(invalidCommitmentReason)}
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to get preimage: %v", resp.StatusCode)

--- a/op-alt-da/daclient_test.go
+++ b/op-alt-da/daclient_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -39,7 +40,7 @@ func TestDAClientPrecomputed(t *testing.T) {
 
 	require.Equal(t, comm, NewKeccak256Commitment(input))
 
-	stored, err := client.GetInput(ctx, comm)
+	stored, err := client.GetInput(ctx, comm, eth.L1BlockRef{})
 	require.NoError(t, err)
 
 	require.Equal(t, input, stored)
@@ -47,12 +48,12 @@ func TestDAClientPrecomputed(t *testing.T) {
 	// set a bad commitment in the store
 	require.NoError(t, store.Put(ctx, comm.Encode(), []byte("bad data")))
 
-	_, err = client.GetInput(ctx, comm)
+	_, err = client.GetInput(ctx, comm, eth.L1BlockRef{})
 	require.ErrorIs(t, err, ErrCommitmentMismatch)
 
 	// test not found error
 	comm = NewKeccak256Commitment(RandomData(rng, 32))
-	_, err = client.GetInput(ctx, comm)
+	_, err = client.GetInput(ctx, comm, eth.L1BlockRef{})
 	require.ErrorIs(t, err, ErrNotFound)
 
 	// test storing bad data
@@ -64,7 +65,7 @@ func TestDAClientPrecomputed(t *testing.T) {
 	_, err = client.SetInput(ctx, input)
 	require.Error(t, err)
 
-	_, err = client.GetInput(ctx, NewKeccak256Commitment(input))
+	_, err = client.GetInput(ctx, NewKeccak256Commitment(input), eth.L1BlockRef{})
 	require.Error(t, err)
 }
 
@@ -98,7 +99,7 @@ func TestDAClientService(t *testing.T) {
 
 	require.Equal(t, comm.String(), NewKeccak256Commitment(input).String())
 
-	stored, err := client.GetInput(ctx, comm)
+	stored, err := client.GetInput(ctx, comm, eth.L1BlockRef{})
 	require.NoError(t, err)
 
 	require.Equal(t, input, stored)
@@ -107,12 +108,12 @@ func TestDAClientService(t *testing.T) {
 	require.NoError(t, store.Put(ctx, comm.Encode(), []byte("bad data")))
 
 	// assert no error as generic commitments cannot be verified client side
-	_, err = client.GetInput(ctx, comm)
+	_, err = client.GetInput(ctx, comm, eth.L1BlockRef{})
 	require.NoError(t, err)
 
 	// test not found error
 	comm = NewKeccak256Commitment(RandomData(rng, 32))
-	_, err = client.GetInput(ctx, comm)
+	_, err = client.GetInput(ctx, comm, eth.L1BlockRef{})
 	require.ErrorIs(t, err, ErrNotFound)
 
 	// test storing bad data
@@ -124,6 +125,6 @@ func TestDAClientService(t *testing.T) {
 	_, err = client.SetInput(ctx, input)
 	require.Error(t, err)
 
-	_, err = client.GetInput(ctx, NewKeccak256Commitment(input))
+	_, err = client.GetInput(ctx, NewKeccak256Commitment(input), eth.L1BlockRef{})
 	require.Error(t, err)
 }

--- a/op-alt-da/daclient_test.go
+++ b/op-alt-da/daclient_test.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -40,7 +39,7 @@ func TestDAClientPrecomputed(t *testing.T) {
 
 	require.Equal(t, comm, NewKeccak256Commitment(input))
 
-	stored, err := client.GetInput(ctx, comm, eth.L1BlockRef{})
+	stored, err := client.GetInput(ctx, comm, 0)
 	require.NoError(t, err)
 
 	require.Equal(t, input, stored)
@@ -48,12 +47,12 @@ func TestDAClientPrecomputed(t *testing.T) {
 	// set a bad commitment in the store
 	require.NoError(t, store.Put(ctx, comm.Encode(), []byte("bad data")))
 
-	_, err = client.GetInput(ctx, comm, eth.L1BlockRef{})
+	_, err = client.GetInput(ctx, comm, 0)
 	require.ErrorIs(t, err, ErrCommitmentMismatch)
 
 	// test not found error
 	comm = NewKeccak256Commitment(RandomData(rng, 32))
-	_, err = client.GetInput(ctx, comm, eth.L1BlockRef{})
+	_, err = client.GetInput(ctx, comm, 0)
 	require.ErrorIs(t, err, ErrNotFound)
 
 	// test storing bad data
@@ -65,7 +64,7 @@ func TestDAClientPrecomputed(t *testing.T) {
 	_, err = client.SetInput(ctx, input)
 	require.Error(t, err)
 
-	_, err = client.GetInput(ctx, NewKeccak256Commitment(input), eth.L1BlockRef{})
+	_, err = client.GetInput(ctx, NewKeccak256Commitment(input), 0)
 	require.Error(t, err)
 }
 
@@ -99,7 +98,7 @@ func TestDAClientService(t *testing.T) {
 
 	require.Equal(t, comm.String(), NewKeccak256Commitment(input).String())
 
-	stored, err := client.GetInput(ctx, comm, eth.L1BlockRef{})
+	stored, err := client.GetInput(ctx, comm, 0)
 	require.NoError(t, err)
 
 	require.Equal(t, input, stored)
@@ -108,12 +107,12 @@ func TestDAClientService(t *testing.T) {
 	require.NoError(t, store.Put(ctx, comm.Encode(), []byte("bad data")))
 
 	// assert no error as generic commitments cannot be verified client side
-	_, err = client.GetInput(ctx, comm, eth.L1BlockRef{})
+	_, err = client.GetInput(ctx, comm, 0)
 	require.NoError(t, err)
 
 	// test not found error
 	comm = NewKeccak256Commitment(RandomData(rng, 32))
-	_, err = client.GetInput(ctx, comm, eth.L1BlockRef{})
+	_, err = client.GetInput(ctx, comm, 0)
 	require.ErrorIs(t, err, ErrNotFound)
 
 	// test storing bad data
@@ -125,6 +124,6 @@ func TestDAClientService(t *testing.T) {
 	_, err = client.SetInput(ctx, input)
 	require.Error(t, err)
 
-	_, err = client.GetInput(ctx, NewKeccak256Commitment(input), eth.L1BlockRef{})
+	_, err = client.GetInput(ctx, NewKeccak256Commitment(input), 0)
 	require.Error(t, err)
 }

--- a/op-alt-da/damgr.go
+++ b/op-alt-da/damgr.go
@@ -40,7 +40,10 @@ type L1Fetcher interface {
 
 // DAStorage interface for calling the DA storage server.
 type DAStorage interface {
-	GetInput(ctx context.Context, key CommitmentData) ([]byte, error)
+	// L1InclusionBlockNumber is the block at which the commitment was included in the batcher inbox.
+	// It is used to check if the commitment is expired, and should be sent as a query parameter
+	// to the DA server.
+	GetInput(ctx context.Context, key CommitmentData, L1InclusionBlock eth.L1BlockRef) ([]byte, error)
 	SetInput(ctx context.Context, img []byte) (CommitmentData, error)
 }
 
@@ -223,7 +226,7 @@ func (d *DA) GetInput(ctx context.Context, l1 L1Fetcher, comm CommitmentData, bl
 	d.log.Info("getting input", "comm", comm, "status", status)
 
 	// Fetch the input from the DA storage.
-	data, err := d.storage.GetInput(ctx, comm)
+	data, err := d.storage.GetInput(ctx, comm, blockId)
 	notFound := errors.Is(ErrNotFound, err)
 	if err != nil && !notFound {
 		d.log.Error("failed to get preimage", "err", err)

--- a/op-alt-da/damgr.go
+++ b/op-alt-da/damgr.go
@@ -231,7 +231,6 @@ func (d *DA) GetInput(ctx context.Context, l1 L1Fetcher, comm CommitmentData, bl
 	if err != nil && !notFound {
 		d.log.Error("failed to get preimage", "err", err)
 		// the storage client request failed for some other reason
-		// in which case derivation pipeline should be retried
 		return nil, err
 	}
 

--- a/op-alt-da/damgr.go
+++ b/op-alt-da/damgr.go
@@ -40,10 +40,10 @@ type L1Fetcher interface {
 
 // DAStorage interface for calling the DA storage server.
 type DAStorage interface {
-	// L1InclusionBlockNumber is the block at which the commitment was included in the batcher inbox.
+	// L1InclusionBlockNumber is the block number at which the commitment was included in the batcher inbox.
 	// It is used to check if the commitment is expired, and should be sent as a query parameter
-	// to the DA server.
-	GetInput(ctx context.Context, key CommitmentData, L1InclusionBlock eth.L1BlockRef) ([]byte, error)
+	// to the DA server. It is optional, and passing a 0 value will tell the DA server to skip the check.
+	GetInput(ctx context.Context, key CommitmentData, L1InclusionBlockNumber uint64) ([]byte, error)
 	SetInput(ctx context.Context, img []byte) (CommitmentData, error)
 }
 
@@ -226,7 +226,7 @@ func (d *DA) GetInput(ctx context.Context, l1 L1Fetcher, comm CommitmentData, bl
 	d.log.Info("getting input", "comm", comm, "status", status)
 
 	// Fetch the input from the DA storage.
-	data, err := d.storage.GetInput(ctx, comm, blockId)
+	data, err := d.storage.GetInput(ctx, comm, blockId.Number)
 	notFound := errors.Is(ErrNotFound, err)
 	if err != nil && !notFound {
 		d.log.Error("failed to get preimage", "err", err)

--- a/op-alt-da/damock.go
+++ b/op-alt-da/damock.go
@@ -30,6 +30,8 @@ type MockDAClient struct {
 	setInputRequestCount   uint // number of put requests received, irrespective of whether they were successful
 }
 
+var _ DAStorage = (*MockDAClient)(nil)
+
 func NewMockDAClient(log log.Logger) *MockDAClient {
 	return &MockDAClient{
 		CommitmentType: Keccak256CommitmentType,
@@ -58,7 +60,7 @@ func (c *MockDAClient) DropEveryNthPut(n uint) {
 	c.dropEveryNthPut = n
 }
 
-func (c *MockDAClient) GetInput(ctx context.Context, key CommitmentData) ([]byte, error) {
+func (c *MockDAClient) GetInput(ctx context.Context, key CommitmentData, _ eth.L1BlockRef) ([]byte, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.log.Debug("Getting input", "key", key)
@@ -121,12 +123,14 @@ type DAErrFaker struct {
 	setInputErr error
 }
 
-func (f *DAErrFaker) GetInput(ctx context.Context, key CommitmentData) ([]byte, error) {
+var _ DAStorage = (*DAErrFaker)(nil)
+
+func (f *DAErrFaker) GetInput(ctx context.Context, key CommitmentData, blockId eth.L1BlockRef) ([]byte, error) {
 	if err := f.getInputErr; err != nil {
 		f.getInputErr = nil
 		return nil, err
 	}
-	return f.Client.GetInput(ctx, key)
+	return f.Client.GetInput(ctx, key, eth.L1BlockRef{})
 }
 
 func (f *DAErrFaker) SetInput(ctx context.Context, data []byte) (CommitmentData, error) {

--- a/op-alt-da/damock.go
+++ b/op-alt-da/damock.go
@@ -60,7 +60,7 @@ func (c *MockDAClient) DropEveryNthPut(n uint) {
 	c.dropEveryNthPut = n
 }
 
-func (c *MockDAClient) GetInput(ctx context.Context, key CommitmentData, _ eth.L1BlockRef) ([]byte, error) {
+func (c *MockDAClient) GetInput(ctx context.Context, key CommitmentData, _ uint64) ([]byte, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.log.Debug("Getting input", "key", key)
@@ -125,12 +125,12 @@ type DAErrFaker struct {
 
 var _ DAStorage = (*DAErrFaker)(nil)
 
-func (f *DAErrFaker) GetInput(ctx context.Context, key CommitmentData, blockId eth.L1BlockRef) ([]byte, error) {
+func (f *DAErrFaker) GetInput(ctx context.Context, key CommitmentData, l1InclusionBlockNumber uint64) ([]byte, error) {
 	if err := f.getInputErr; err != nil {
 		f.getInputErr = nil
 		return nil, err
 	}
-	return f.Client.GetInput(ctx, key, eth.L1BlockRef{})
+	return f.Client.GetInput(ctx, key, l1InclusionBlockNumber)
 }
 
 func (f *DAErrFaker) SetInput(ctx context.Context, data []byte) (CommitmentData, error) {

--- a/op-e2e/actions/altda/altda_test.go
+++ b/op-e2e/actions/altda/altda_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
@@ -270,7 +271,7 @@ func (a *L2AltDA) ActResolveInput(t helpers.Testing, comm []byte, input []byte, 
 
 func (a *L2AltDA) ActResolveLastChallenge(t helpers.Testing) {
 	// remove derivation byte prefix
-	input, err := a.storage.GetInput(t.Ctx(), altda.Keccak256Commitment(a.lastComm[1:]))
+	input, err := a.storage.GetInput(t.Ctx(), altda.Keccak256Commitment(a.lastComm[1:]), eth.L1BlockRef{})
 	require.NoError(t, err)
 
 	a.ActResolveInput(t, a.lastComm, input, a.lastCommBn)
@@ -476,7 +477,7 @@ func TestAltDA_SequencerStalledMultiChallenges(gt *testing.T) {
 
 	// keep track of the related commitment
 	comm1 := a.lastComm
-	input1, err := a.storage.GetInput(t.Ctx(), altda.Keccak256Commitment(comm1[1:]))
+	input1, err := a.storage.GetInput(t.Ctx(), altda.Keccak256Commitment(comm1[1:]), eth.L1BlockRef{})
 	bn1 := a.lastCommBn
 	require.NoError(t, err)
 
@@ -525,7 +526,7 @@ func TestAltDA_SequencerStalledMultiChallenges(gt *testing.T) {
 
 	// keep track of the second commitment
 	comm2 := a.lastComm
-	_, err = a.storage.GetInput(t.Ctx(), altda.Keccak256Commitment(comm2[1:]))
+	_, err = a.storage.GetInput(t.Ctx(), altda.Keccak256Commitment(comm2[1:]), eth.L1BlockRef{})
 	require.NoError(t, err)
 	a.lastCommBn = a.miner.L1Chain().CurrentBlock().Number.Uint64()
 

--- a/op-e2e/actions/altda/altda_test.go
+++ b/op-e2e/actions/altda/altda_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
-	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 )
@@ -271,7 +270,7 @@ func (a *L2AltDA) ActResolveInput(t helpers.Testing, comm []byte, input []byte, 
 
 func (a *L2AltDA) ActResolveLastChallenge(t helpers.Testing) {
 	// remove derivation byte prefix
-	input, err := a.storage.GetInput(t.Ctx(), altda.Keccak256Commitment(a.lastComm[1:]), eth.L1BlockRef{})
+	input, err := a.storage.GetInput(t.Ctx(), altda.Keccak256Commitment(a.lastComm[1:]), 0)
 	require.NoError(t, err)
 
 	a.ActResolveInput(t, a.lastComm, input, a.lastCommBn)
@@ -477,7 +476,7 @@ func TestAltDA_SequencerStalledMultiChallenges(gt *testing.T) {
 
 	// keep track of the related commitment
 	comm1 := a.lastComm
-	input1, err := a.storage.GetInput(t.Ctx(), altda.Keccak256Commitment(comm1[1:]), eth.L1BlockRef{})
+	input1, err := a.storage.GetInput(t.Ctx(), altda.Keccak256Commitment(comm1[1:]), 0)
 	bn1 := a.lastCommBn
 	require.NoError(t, err)
 
@@ -526,7 +525,7 @@ func TestAltDA_SequencerStalledMultiChallenges(gt *testing.T) {
 
 	// keep track of the second commitment
 	comm2 := a.lastComm
-	_, err = a.storage.GetInput(t.Ctx(), altda.Keccak256Commitment(comm2[1:]), eth.L1BlockRef{})
+	_, err = a.storage.GetInput(t.Ctx(), altda.Keccak256Commitment(comm2[1:]), 0)
 	require.NoError(t, err)
 	a.lastCommBn = a.miner.L1Chain().CurrentBlock().Number.Uint64()
 

--- a/op-node/rollup/derive/altda_data_source.go
+++ b/op-node/rollup/derive/altda_data_source.go
@@ -75,6 +75,7 @@ func (s *AltDADataSource) Next(ctx context.Context) (eth.Data, error) {
 	}
 	// use the commitment to fetch the input from the AltDA provider.
 	data, err := s.fetcher.GetInput(ctx, s.l1, s.comm, s.id)
+	var invalidCommitmentError altda.InvalidCommitmentError
 	// GetInput may call for a reorg if the pipeline is stalled and the AltDA manager
 	// continued syncing origins detached from the pipeline origin.
 	if errors.Is(err, altda.ErrReorgRequired) {
@@ -91,6 +92,10 @@ func (s *AltDADataSource) Next(ctx context.Context) (eth.Data, error) {
 	} else if errors.Is(err, altda.ErrPendingChallenge) {
 		// continue stepping without slowing down.
 		return nil, NotEnoughData
+	} else if errors.As(err, &invalidCommitmentError) {
+		s.log.Warn("skipping invalid commitment", "comm", s.comm, "err", err)
+		s.comm = nil
+		return s.Next(ctx) // skip the input
 	} else if err != nil {
 		// return temporary error so we can keep retrying.
 		return nil, NewTemporaryError(fmt.Errorf("failed to fetch input data with comm %s from da service: %w", s.comm, err))


### PR DESCRIPTION
Not quite sure what we'll end up calling this check: punctuality, recency, timing, etc.
But main idea is that the derivation pipeline needs a way to prevent a malicious batcher from submitting an old cert whose data is no longer available on the DA Layer from stalling the derivation pipeline. So the rollup needs to have a rule to discard these certs as invalid. See https://github.com/Layr-Labs/eigenda/pull/1533 for discussions related to this.

This change simply passes the l1_inclusion_block_number at which a commitment was included in the batcher inbox as a query param to GET requests submitted to da-server, where the da-server can encode the rule that different rollups/da-layers want to enforce. Here's the [related PR](https://github.com/Layr-Labs/eigenda-proxy/pull/378) for eigenda-proxy to support this query param.

TODO: add tests