### PR TITLE
create new commit

### DIFF
--- a/op-e2e/actions/proofs/simple_program_with_eigenda_test.go
+++ b/op-e2e/actions/proofs/simple_program_with_eigenda_test.go
@@ -16,6 +16,7 @@ import (
 
 func runSimpleProgramWithEigenDATest(gt *testing.T, testCfg *helpers.TestCfg[any]) {
 	t := actionsHelpers.NewDefaultTesting(gt)
+
 	testSetup := func(dc *genesis.DeployConfig) {
 		dc.L1PragueTimeOffset = ptr(hexutil.Uint64(0))
 		// Set non-trivial excess blob gas so that the L1 miner's blob logic is


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR adds a framework to test eigenda against op-e2e. The final goal is to test equivalence 
op-program+proxy= hokulea+proxy.

This PR is the initial step to run op-program against eigenda-proxy

<!--
A clear and concise description of the features you're adding in this pull request.
-->

To run the test, the user must start an instance of eigenda proxy in memstore mode with port open at 3100, then run 
```
op-e2e/actions/proofs
go test  -run Test_ProgramAction_SimpleEmptyChainWithEigenDA -v
```